### PR TITLE
Add mech Actions tab with PP actions, combat regen, and rollable saves

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -3309,6 +3309,7 @@
                 "UpperLimbs": "Upper Limbs"
             },
             "Tabs": {
+                "Actions": "Actions",
                 "Components": "Components",
                 "Operators": "Operators",
                 "Weapons": "Weapons",
@@ -3402,6 +3403,70 @@
                     "Speed": "Speed (ft.)"
                 },
                 "Contents": "Pod Contents"
+            },
+            "Action": {
+                "Actions": "Special Actions",
+                "Name": "Action Name",
+                "Description": "Description",
+                "PpCost": "PP Cost",
+                "ActionType": "Action Type",
+                "AddAction": "Add Action",
+                "RemoveAction": "Remove Action"
+            },
+            "Actions": {
+                "EnabledWeapons": "Enabled Weapons",
+                "PPActions": "PP Actions",
+                "SpecialActions": "Special Actions",
+                "GearActions": "Gear Actions",
+                "NoEnabledWeapons": "No weapons mounted",
+                "NoGearActions": "No gear actions available",
+                "InsufficientPP": "Insufficient Power Points to perform this action.",
+                "PPSpent": "{amount} PP spent",
+                "PPRegenMessage": "{name} regenerates {amount} PP ({current}/{max})",
+                "PP": {
+                    "Aim": {
+                        "Name": "Aim",
+                        "Description": "Before attempting an attack roll, roll 1d4 and add the result as an insight bonus to the attack roll."
+                    },
+                    "DevastatingHit": {
+                        "Name": "Devastating Hit",
+                        "Description": "After hitting a creature with an attack, but before dealing damage, increase the weapon's damage value by one step (e.g., medium damage instead deals high damage). A weapon that already deals extreme damage instead adds 1 additional damage for every damage die rolled. This can't be used for weapons that attack an intersection rather than a creature."
+                    },
+                    "Maneuver": {
+                        "Name": "Maneuver",
+                        "Description": "Choose one skill. Until the beginning of the mech's next turn, operators add any insight bonuses they have that apply to that skill to the mech's checks with that skill."
+                    },
+                    "Replenish": {
+                        "Name": "Replenish",
+                        "Description": "Activate when regaining Shield Points. The number of SP the mech recovers increases by 1d8. This increases by an additional 1d8 at tier 5 and every 5 tiers thereafter."
+                    },
+                    "Resist": {
+                        "Name": "Resist",
+                        "Description": "Before attempting a saving throw, roll 1d4 and add the result as a resistance bonus to the saving throw."
+                    }
+                },
+                "Special": {
+                    "CalledShot": {
+                        "Name": "Called Shot",
+                        "Description": "Expend 1 or 3 PP and make an attack against a single mech. If the attack's damage causes system damage, choose which component takes the damage (excluding power core or cockpit). If 3 PP were expended, any component can be selected."
+                    },
+                    "Hurl": {
+                        "Name": "Hurl",
+                        "Description": "Grab a nearby object and throw it as a ranged attack with a 30-foot range increment. The object can be at most two size categories smaller than the mech. Maximum or next-smallest size objects deal medium damage; smaller objects deal light damage. Throwing a creature or vehicle requires a successful grapple combat maneuver."
+                    },
+                    "Scan": {
+                        "Name": "Scan",
+                        "Description": "Use the sensor array to study one creature, mech, or object observed with a precise sense. Against a creature, this functions as a check to identify using the mech's Computers bonus. Success also grants a +1 insight bonus to the next attack against that creature. Against a mech or object, a Computers check reveals information about it. Each additional scan of the same target within an hour costs 1 PP per previous attempt."
+                    }
+                },
+                "ActionTypes": {
+                    "Standard": "Standard",
+                    "Move": "Move",
+                    "Full": "Full",
+                    "Swift": "Swift",
+                    "Reaction": "Reaction",
+                    "Constant": "Constant"
+                }
             },
             "Weapon": {
                 "Area": "Area",

--- a/src/items/mech-components/assault_arms.json
+++ b/src/items/mech-components/assault_arms.json
@@ -5,6 +5,14 @@
   "folder": "XyGHG8VPLQ1F0WWL",
   "img": "systems/sfrpg/icons/mech-frame.png",
   "system": {
+    "actions": [
+      {
+        "name": "Dual Strike",
+        "actionType": "full",
+        "description": "When making a full attack with two different weapons mounted on your arms, you attack twice with one weapon and once with the other.",
+        "ppCost": 1
+      }
+    ],
     "baseHp": 0,
     "canBeActivated": true,
     "description": {

--- a/src/items/mech-components/auger.json
+++ b/src/items/mech-components/auger.json
@@ -5,6 +5,14 @@
   "folder": "kAhhXt15enjibCol",
   "img": "systems/sfrpg/icons/mech-frame.png",
   "system": {
+    "actions": [
+      {
+        "name": "Excavate",
+        "actionType": "full",
+        "description": "As a full action, the mech can increase its burrow speed to its full land speed for 1 round, creating a tunnel 25 feet wide that other creatures and vehicles can move through.",
+        "ppCost": 2
+      }
+    ],
     "baseHp": 4,
     "canBeActivated": true,
     "description": {

--- a/src/items/mech-components/autospear.json
+++ b/src/items/mech-components/autospear.json
@@ -5,6 +5,14 @@
   "folder": "yxRJ0fA0zyqCjCBH",
   "img": "systems/sfrpg/icons/equipment/weapons/cryopike.webp",
   "system": {
+    "actions": [
+      {
+        "name": "Projectile Mode",
+        "actionType": "move",
+        "description": "As a move action, the mech reconfigures the autospear from a melee weapon into a ranged weapon that fires flechettes. The autospear loses the reach and thrown weapon special properties in this form and gains the line weapon special property, a range of 100 feet, and a capacity of 5. The mech can reconfigure it back as a move action at no PP cost.",
+        "ppCost": 1
+      }
+    ],
     "area": "",
     "capacity": 5,
     "damage": {

--- a/src/items/mech-components/autotarget.json
+++ b/src/items/mech-components/autotarget.json
@@ -5,6 +5,14 @@
   "folder": "vj3kvHdvf2DlBF6O",
   "img": "systems/sfrpg/icons/equipment/technological items/omnidirectional_camera.webp",
   "system": {
+    "actions": [
+      {
+        "name": "Accurate Strikes",
+        "actionType": "",
+        "description": "For 1 round, the mech treats all of its operators as though they each had a number of Piloting ranks equal to their respective levels for the purpose of calculating the mech's attack bonuses.",
+        "ppCost": 1
+      }
+    ],
     "canBeActivated": true,
     "description": {
       "chat": "",

--- a/src/items/mech-components/biped_fast.json
+++ b/src/items/mech-components/biped_fast.json
@@ -5,6 +5,14 @@
   "folder": "kAhhXt15enjibCol",
   "img": "systems/sfrpg/icons/mech-frame.png",
   "system": {
+    "actions": [
+      {
+        "name": "Sprint",
+        "actionType": "swift",
+        "description": "As a swift action, the mech gains a +10-foot enhancement bonus to its speed for 1 round.",
+        "ppCost": 1
+      }
+    ],
     "baseHp": 2,
     "canBeActivated": true,
     "description": {

--- a/src/items/mech-components/biped_heavy.json
+++ b/src/items/mech-components/biped_heavy.json
@@ -5,6 +5,14 @@
   "folder": "kAhhXt15enjibCol",
   "img": "systems/sfrpg/icons/mech-frame.png",
   "system": {
+    "actions": [
+      {
+        "name": "Trample",
+        "actionType": "full",
+        "description": "As a full action, the mech uses the trample universal creature ability. This deals low bludgeoning damage as a mech weapon with a level equal to the mech's tier. The Reflex save DC equals 12 + 1/2 x the mech's tier.",
+        "ppCost": 2
+      }
+    ],
     "baseHp": 4,
     "canBeActivated": true,
     "description": {

--- a/src/items/mech-components/cargo_catapult.json
+++ b/src/items/mech-components/cargo_catapult.json
@@ -5,6 +5,14 @@
   "folder": "vj3kvHdvf2DlBF6O",
   "img": "systems/sfrpg/icons/default/power-generator.svg",
   "system": {
+    "actions": [
+      {
+        "name": "Dispatch Hot",
+        "actionType": "standard",
+        "description": "As a standard action, the mech can transfer one operator into a vehicle stored in its cargo hold, after which the mech launches the stored vehicle at high speed using the race action. The pilot of the launched vehicle doesn't need to succeed at a Piloting check as part of the race action this turn.",
+        "ppCost": 3
+      }
+    ],
     "canBeActivated": true,
     "description": {
       "chat": "",

--- a/src/items/mech-components/chainwhip.json
+++ b/src/items/mech-components/chainwhip.json
@@ -5,6 +5,14 @@
   "folder": "ufslMqZOMYF7vkkO",
   "img": "systems/sfrpg/icons/equipment/weapons/curveblade.webp",
   "system": {
+    "actions": [
+      {
+        "name": "Lash",
+        "actionType": "standard",
+        "description": "As a standard action, the mech makes an attack against multiple targets in an area as though the chainwhip had the blast weapon special property. The length of the cone equals the mech's reach with the chainwhip.",
+        "ppCost": 2
+      }
+    ],
     "area": "",
     "capacity": null,
     "damage": {

--- a/src/items/mech-components/cloaker.json
+++ b/src/items/mech-components/cloaker.json
@@ -5,6 +5,20 @@
   "folder": "vj3kvHdvf2DlBF6O",
   "img": "systems/sfrpg/icons/equipment/technological items/emergency_defense_sphere.webp",
   "system": {
+    "actions": [
+      {
+        "name": "Fade",
+        "actionType": "full",
+        "description": "As a full action, the mech initiates active camouflage, granting it concealment until it makes an attack or performs other harmful actions. If the mech begins combat while this ability is active, it begins the encounter with 1 less PP (minimum 1).",
+        "ppCost": 0
+      },
+      {
+        "name": "Cloak",
+        "actionType": "standard",
+        "description": "As a standard action, the mech fades from view as per invisibility. The effect lasts for 1 round, though the mech can extend the duration each round by expending 1 PP. The effect ends if the mech makes an attack or performs other harmful actions.",
+        "ppCost": 4
+      }
+    ],
     "canBeActivated": true,
     "description": {
       "chat": "",

--- a/src/items/mech-components/emp_cannon.json
+++ b/src/items/mech-components/emp_cannon.json
@@ -5,6 +5,26 @@
   "folder": "vj3kvHdvf2DlBF6O",
   "img": "systems/sfrpg/icons/equipment/weapons/advanced_zero_cannon.webp",
   "system": {
+    "actions": [
+      {
+        "name": "Jam Weapon",
+        "actionType": "standard",
+        "description": "As a standard action, make a ranged attack against another mech within 120 feet, optionally targeting one weapon. If it hits, the selected weapon becomes nonfunctional for 1 minute unless the targeted mech succeeds at a Fortitude save.",
+        "ppCost": 3
+      },
+      {
+        "name": "Kill Engine",
+        "actionType": "standard",
+        "description": "As a standard action, make a ranged attack against another mech within 120 feet, selecting one movement type. If it hits, that speed is reduced to 0 feet for 1 round unless the targeted mech succeeds at a Fortitude save.",
+        "ppCost": 4
+      },
+      {
+        "name": "Sabotage Power",
+        "actionType": "standard",
+        "description": "As a standard action, make a ranged attack against another mech within 120 feet, targeting its power core. If it hits, the targeted mech can't regain or expend Power Points for 1 round unless it succeeds at a Fortitude save.",
+        "ppCost": 3
+      }
+    ],
     "canBeActivated": true,
     "description": {
       "chat": "",

--- a/src/items/mech-components/explosive_self-destruct.json
+++ b/src/items/mech-components/explosive_self-destruct.json
@@ -5,6 +5,7 @@
   "folder": "vj3kvHdvf2DlBF6O",
   "img": "systems/sfrpg/icons/equipment/technological items/detonator.webp",
   "system": {
+    "actions": [],
     "canBeActivated": true,
     "description": {
       "chat": "",

--- a/src/items/mech-components/frostspear.json
+++ b/src/items/mech-components/frostspear.json
@@ -5,6 +5,14 @@
   "folder": "ufslMqZOMYF7vkkO",
   "img": "systems/sfrpg/icons/equipment/weapons/cryopike.webp",
   "system": {
+    "actions": [
+      {
+        "name": "Cold Snap",
+        "actionType": "standard",
+        "description": "As a standard action, the mech makes an attack against multiple targets in an area as though the frostspear had the line weapon special property. The length of the line equals twice the mech's reach with the frostspear.",
+        "ppCost": 2
+      }
+    ],
     "area": "",
     "capacity": null,
     "damage": {

--- a/src/items/mech-components/glider_wings.json
+++ b/src/items/mech-components/glider_wings.json
@@ -5,6 +5,14 @@
   "folder": "vj3kvHdvf2DlBF6O",
   "img": "systems/sfrpg/icons/equipment/technological items/glider_foils.webp",
   "system": {
+    "actions": [
+      {
+        "name": "Glide",
+        "actionType": "",
+        "description": "Add 30 feet to the maximum height of your Power Jump. The mech floats until your next turn or falls at a rate of 5 feet per round.",
+        "ppCost": 1
+      }
+    ],
     "canBeActivated": true,
     "description": {
       "chat": "",

--- a/src/items/mech-components/haste_circuit.json
+++ b/src/items/mech-components/haste_circuit.json
@@ -5,6 +5,14 @@
   "folder": "vj3kvHdvf2DlBF6O",
   "img": "systems/sfrpg/icons/equipment/technological items/emergency_defense_sphere.webp",
   "system": {
+    "actions": [
+      {
+        "name": "Speed Surge",
+        "actionType": "",
+        "description": "Each time this ability is activated, the mech increases the number of times it can use an action to move by 1, exceeding the normal limit of two movements per turn. This auxiliary system can be used more than once per turn.",
+        "ppCost": 2
+      }
+    ],
     "canBeActivated": true,
     "description": {
       "chat": "",

--- a/src/items/mech-components/plasma-shock_circuits.json
+++ b/src/items/mech-components/plasma-shock_circuits.json
@@ -5,6 +5,14 @@
   "folder": "vj3kvHdvf2DlBF6O",
   "img": "systems/sfrpg/icons/equipment/technological items/emergency_defense_sphere.webp",
   "system": {
+    "actions": [
+      {
+        "name": "Energized Retort",
+        "actionType": "reaction",
+        "description": "As a reaction when the mech takes damage that causes it to lose Shield Points, the mech channels the shields' lost energy into one of its weapons that deals energy damage. The next time that weapon deals damage before the end of the mech's next turn, it deals additional damage equal to half the SP lost from the triggering attack.",
+        "ppCost": 2
+      }
+    ],
     "canBeActivated": true,
     "description": {
       "chat": "",

--- a/src/items/mech-components/plow_plating.json
+++ b/src/items/mech-components/plow_plating.json
@@ -5,6 +5,14 @@
   "folder": "vj3kvHdvf2DlBF6O",
   "img": "systems/sfrpg/icons/default/power-generator.svg",
   "system": {
+    "actions": [
+      {
+        "name": "Bulldoze",
+        "actionType": "",
+        "description": "Activate when attempting a bull rush or reposition combat maneuver. The mech gains a +2 bonus to the attack roll, and if the maneuver succeeds, the target also takes damage equal to the mech's tier plus its Strength modifier.",
+        "ppCost": 2
+      }
+    ],
     "canBeActivated": true,
     "description": {
       "chat": "",

--- a/src/items/mech-components/rocket_launcher.json
+++ b/src/items/mech-components/rocket_launcher.json
@@ -5,6 +5,14 @@
   "folder": "yxRJ0fA0zyqCjCBH",
   "img": "systems/sfrpg/icons/equipment/weapons/imds_missile_launcher.webp",
   "system": {
+    "actions": [
+      {
+        "name": "Siege Mode",
+        "actionType": "full",
+        "description": "As a full action, the mech reconfigures into a siege configuration. While configured, the mech can't fly, other movement speeds are reduced to 10 feet. The rocket launcher's range increases to 500 feet, its explode radius increases to 20 feet, and it deals medium damage. The mech can end the configuration as a full action.",
+        "ppCost": 3
+      }
+    ],
     "area": "explode (10 ft.)",
     "capacity": 2,
     "damage": {

--- a/src/items/mech-components/scythe.json
+++ b/src/items/mech-components/scythe.json
@@ -5,6 +5,14 @@
   "folder": "ufslMqZOMYF7vkkO",
   "img": "systems/sfrpg/icons/equipment/weapons/grindblade.webp",
   "system": {
+    "actions": [
+      {
+        "name": "Cleave",
+        "actionType": "standard",
+        "description": "As a standard action, the mech makes an attack against multiple targets in an area as though the scythe had the blast weapon special property. The length of the cone equals the mech's reach with the scythe.",
+        "ppCost": 2
+      }
+    ],
     "area": "",
     "capacity": null,
     "damage": {

--- a/src/items/mech-components/spear.json
+++ b/src/items/mech-components/spear.json
@@ -5,6 +5,14 @@
   "folder": "ufslMqZOMYF7vkkO",
   "img": "systems/sfrpg/icons/equipment/weapons/cryopike.webp",
   "system": {
+    "actions": [
+      {
+        "name": "Skewer",
+        "actionType": "standard",
+        "description": "As a standard action, the mech makes an attack against multiple targets in an area as though the spear had the line weapon special property. The length of the line equals the mech's reach with the spear.",
+        "ppCost": 1
+      }
+    ],
     "area": "",
     "capacity": null,
     "damage": {

--- a/src/items/mech-components/spiked_shield.json
+++ b/src/items/mech-components/spiked_shield.json
@@ -5,6 +5,14 @@
   "folder": "ufslMqZOMYF7vkkO",
   "img": "systems/sfrpg/icons/equipment/armor/knights-shield-basic.webp",
   "system": {
+    "actions": [
+      {
+        "name": "Deflect",
+        "actionType": "move",
+        "description": "As a move action, the mech positions its shield to intercept incoming attacks, granting a +1 shield bonus to AC and Reflex saving throws until the beginning of its next turn. While active, the mech can use a reaction to double its hardness against one attack's damage.",
+        "ppCost": null
+      }
+    ],
     "area": "",
     "capacity": null,
     "damage": {

--- a/src/items/mech-components/swordwhip.json
+++ b/src/items/mech-components/swordwhip.json
@@ -5,6 +5,14 @@
   "folder": "ufslMqZOMYF7vkkO",
   "img": "systems/sfrpg/icons/equipment/weapons/curveblade.webp",
   "system": {
+    "actions": [
+      {
+        "name": "Whip Mode",
+        "actionType": "move",
+        "description": "As a move action, the mech reconfigures the swordwhip from a solid blade into a fiery, shearing lash for 1 round. In this form, the swordwhip gains the reach and trip special weapon properties, the burn critical hit effect, and deals a combination of fire and slashing damage.",
+        "ppCost": 1
+      }
+    ],
     "area": "",
     "capacity": null,
     "damage": {

--- a/src/items/mech-components/systems_jammer.json
+++ b/src/items/mech-components/systems_jammer.json
@@ -5,6 +5,14 @@
   "folder": "vj3kvHdvf2DlBF6O",
   "img": "systems/sfrpg/icons/equipment/technological items/comm-unit-personal.webp",
   "system": {
+    "actions": [
+      {
+        "name": "Overload Sensors",
+        "actionType": "standard",
+        "description": "As a standard action, make a ranged attack against another mech within 120 feet. If it hits, the targeted mech gains the blinded and deafened conditions for 1 round and loses any blindsense; the targeted mech must succeed at a Fortitude save to negate (DC = 12 + 1/2 mech's tier).",
+        "ppCost": 4
+      }
+    ],
     "canBeActivated": true,
     "description": {
       "chat": "",

--- a/src/items/mech-components/teleporter.json
+++ b/src/items/mech-components/teleporter.json
@@ -5,6 +5,14 @@
   "folder": "vj3kvHdvf2DlBF6O",
   "img": "systems/sfrpg/icons/equipment/technological items/emergency_defense_sphere.webp",
   "system": {
+    "actions": [
+      {
+        "name": "Phase",
+        "actionType": "standard",
+        "description": "As a standard action, the mech instantly teleports itself and its operators to any point within 60 feet that it can see, as per dimension door. For each additional PP expended, the range increases by 60 feet.",
+        "ppCost": 2
+      }
+    ],
     "canBeActivated": true,
     "description": {
       "chat": "",

--- a/src/items/mech-components/thrusters.json
+++ b/src/items/mech-components/thrusters.json
@@ -5,6 +5,14 @@
   "folder": "vj3kvHdvf2DlBF6O",
   "img": "systems/sfrpg/icons/equipment/technological items/glider_foils.webp",
   "system": {
+    "actions": [
+      {
+        "name": "Power Jump",
+        "actionType": "move",
+        "description": "Activate as part of a move action, granting a fly speed of 60 feet (average maneuverability) with a maximum height of 30 feet. The mech must either land at the end of this movement, expend additional PP for more jumps before end of turn, or fall.",
+        "ppCost": 2
+      }
+    ],
     "canBeActivated": true,
     "description": {
       "chat": "",

--- a/src/items/mech-components/thundergauntlet.json
+++ b/src/items/mech-components/thundergauntlet.json
@@ -5,6 +5,14 @@
   "folder": "ufslMqZOMYF7vkkO",
   "img": "systems/sfrpg/icons/equipment/weapons/plasma-claw-organic.webp",
   "system": {
+    "actions": [
+      {
+        "name": "Thunderclap",
+        "actionType": "standard",
+        "description": "As a standard action, use the thundergauntlet as a ranged weapon with the blast special property and 30-foot range. If the mech has two thundergauntlets, it can use both to deal medium damage rather than low damage.",
+        "ppCost": 1
+      }
+    ],
     "area": "",
     "capacity": null,
     "damage": {

--- a/src/items/mech-components/weapon_core.json
+++ b/src/items/mech-components/weapon_core.json
@@ -5,6 +5,20 @@
   "folder": "vj3kvHdvf2DlBF6O",
   "img": "systems/sfrpg/icons/equipment/technological items/emergency_defense_sphere.webp",
   "system": {
+    "actions": [
+      {
+        "name": "Energize Weapon",
+        "actionType": "",
+        "description": "As part of a standard or full action used to make attacks with a melee weapon, charge the weapon with one of the weapon core's energy types. Until end of turn, half of the weapon's damage is replaced with the chosen energy type.",
+        "ppCost": 2
+      },
+      {
+        "name": "Boomerang Strike",
+        "actionType": "",
+        "description": "As part of a standard action to make a ranged attack with a thrown melee weapon, infuse the weapon with telekinetic magic, granting the returning weapon fusion for 1 minute. Only applies to mech weapons, not improvised weapons.",
+        "ppCost": 2
+      }
+    ],
     "canBeActivated": true,
     "description": {
       "chat": "",

--- a/src/less/mech.less
+++ b/src/less/mech.less
@@ -177,6 +177,147 @@
     }
 
     /* ----------------------------------------- */
+    /*  Actions Tab                              */
+    /* ----------------------------------------- */
+
+    .tab.actions {
+        overflow-y: auto;
+        padding: 0 5px;
+
+        .mech-action-list {
+            list-style: none;
+            margin: 0 0 8px 0;
+            padding: 0;
+        }
+
+        .mech-action-header {
+            margin: 2px 0;
+            padding: 4px 8px;
+            background: rgba(0, 0, 0, 0.05);
+            border: 1px solid @colorBeige;
+            border-radius: 3px;
+
+            h3 {
+                margin: 0;
+                font-size: var(--font-size-14);
+                font-weight: bold;
+                line-height: 24px;
+            }
+        }
+
+        .mech-action-item {
+            display: flex;
+            align-items: center;
+            padding: 4px 8px;
+            border-bottom: 1px solid var(--color-border-light-tertiary);
+            line-height: 28px;
+
+            &:hover {
+                background: rgba(0, 0, 0, 0.03);
+            }
+
+            &.empty-slot {
+                font-style: italic;
+                color: var(--color-text-dark-secondary);
+                font-size: var(--font-size-12);
+            }
+
+            .mech-action-name {
+                flex: 1;
+                display: flex;
+                align-items: center;
+                gap: 5px;
+                min-width: 0;
+
+                .item-image {
+                    flex: 0 0 24px;
+                    width: 24px;
+                    height: 24px;
+                    background-size: contain;
+                    background-repeat: no-repeat;
+                    background-position: center;
+                }
+
+                h4 {
+                    margin: 0;
+                    font-size: var(--font-size-13);
+                    cursor: default;
+                    white-space: nowrap;
+                    overflow: hidden;
+                    text-overflow: ellipsis;
+                }
+
+                &[data-tooltip] h4 {
+                    cursor: help;
+                    border-bottom: 1px dotted var(--color-text-dark-secondary);
+                }
+            }
+
+            .mech-action-buttons {
+                flex: 0 0 auto;
+                display: flex;
+                gap: 4px;
+                margin-left: 8px;
+
+                button.tag {
+                    font-size: var(--font-size-11);
+                    padding: 2px 8px;
+                    border: none;
+                    border-radius: 3px;
+                    cursor: pointer;
+                    min-width: 55px;
+                    text-align: center;
+                    line-height: 20px;
+                    white-space: nowrap;
+                }
+
+                button.attack {
+                    background: @sfrpgBlue;
+                    color: white;
+
+                    &:hover {
+                        background: darken(@sfrpgBlue, 10%);
+                    }
+                }
+
+                button.damage {
+                    background: @sfrpgRed;
+                    color: white;
+                    min-width: 80px;
+
+                    &:hover {
+                        background: darken(@sfrpgRed, 10%);
+                    }
+                }
+
+                button.pp-cost-button {
+                    background: @sfrpgBlue;
+                    color: white;
+
+                    &:hover:not(:disabled) {
+                        background: darken(@sfrpgBlue, 10%);
+                    }
+
+                    &:disabled, &.disabled {
+                        background: #999;
+                        cursor: not-allowed;
+                        opacity: 0.6;
+                    }
+                }
+
+                button.action-type-button {
+                    background: @sfrpgGreen;
+                    color: white;
+
+                    &:hover {
+                        background: darken(@sfrpgGreen, 10%);
+                    }
+                }
+            }
+        }
+    }
+
+    /* ----------------------------------------- */
     /*  Mission Pods Section                     */
     /* ----------------------------------------- */
 
@@ -248,6 +389,57 @@
                     align-items: center;
                     justify-content: center;
                 }
+            }
+        }
+    }
+}
+
+/* ----------------------------------------- */
+/*  Mech Action Chat Card                    */
+/* ----------------------------------------- */
+
+.sfrpg.chat-card.mech-action-card {
+    .card-pp-spent {
+        padding: 4px 0 0;
+        font-size: var(--font-size-11);
+        font-style: italic;
+        color: var(--color-text-dark-secondary);
+        text-align: right;
+    }
+}
+
+/* ----------------------------------------- */
+/*  Mech Action Editing (Item Sheets)        */
+/* ----------------------------------------- */
+
+.sfrpg .mech-actions-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+
+    .mech-action-entry {
+        margin-bottom: 8px;
+        padding: 5px;
+        border: 1px solid var(--color-border-light-tertiary);
+        border-radius: 3px;
+        background: rgba(0, 0, 0, 0.02);
+
+        .mech-action-entry-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 4px;
+
+            .mech-action-entry-title {
+                font-weight: bold;
+                font-size: var(--font-size-13);
+            }
+        }
+
+        .mech-action-entry-fields {
+            textarea {
+                width: 100%;
+                resize: vertical;
             }
         }
     }

--- a/src/module/actor/sheet/base.js
+++ b/src/module/actor/sheet/base.js
@@ -519,15 +519,47 @@ export class ActorSheetSFRPG extends foundry.appv1.sheets.ActorSheet {
             const actor = item.actor;
             const actorData = actor.system;
 
-            // Mech weapons: base attack (tier + limbs) shown on sheet;
-            // operator's BAB/Piloting is added at roll time
+            // Mech weapons: base attack (tier + limbs) + best operator bonus
             if (item.type === "mechWeapon") {
                 const isMelee = itemData.weaponType === "melee";
                 const baseAttack = isMelee
                     ? actorData.attributes?.meleeAttackBonus || 0
                     : actorData.attributes?.rangedAttackBonus || 0;
-                const sign = baseAttack >= 0 ? "+" : "";
-                item.config.attackString = `${sign}${baseAttack} + ${game.i18n.localize("SFRPG.MechSheet.OperatorBonus")}`;
+
+                const tooltipParts = [];
+                const existingTooltip = actorData.attributes?.attackBonus?.tooltip || [];
+                for (const entry of existingTooltip) {
+                    if (isMelee && entry.includes("(Ranged)")) continue;
+                    if (!isMelee && entry.includes("(Melee)")) continue;
+                    if (entry.includes("Operator")) continue;
+                    tooltipParts.push(entry);
+                }
+
+                let operatorBonus = 0;
+                let bestOperatorName = null;
+                let bestOperatorSource = null;
+                const operatorIds = actorData.crew?.operator?.actorIds || [];
+                for (const id of operatorIds) {
+                    const op = game.actors.get(id);
+                    if (!op) continue;
+                    const bab = op.system.attributes?.baseAttackBonus?.value || 0;
+                    const pilRanks = op.system.skills?.pil?.ranks || 0;
+                    const best = Math.max(bab, pilRanks);
+                    if (best > operatorBonus) {
+                        operatorBonus = best;
+                        bestOperatorName = op.name;
+                        bestOperatorSource = best === pilRanks ? "Piloting" : "BAB";
+                    }
+                }
+
+                if (bestOperatorName) {
+                    tooltipParts.push(`${bestOperatorName} (${bestOperatorSource}): +${operatorBonus}`);
+                }
+
+                const total = baseAttack + operatorBonus;
+                const sign = total >= 0 ? "+" : "";
+                item.config.attackString = `${sign}${total}`;
+                item.config.attackTooltip = tooltipParts.join("\n");
                 return;
             }
 

--- a/src/module/actor/sheet/mech.js
+++ b/src/module/actor/sheet/mech.js
@@ -15,7 +15,7 @@ export class ActorSheetSFRPGMech extends ActorSheetSFRPG {
 
     static get defaultOptions() {
         const options = super.defaultOptions;
-        options.scrollY = [...(options.scrollY || []), ".tab.details", ".tab.features"];
+        options.scrollY = [...(options.scrollY || []), ".tab.details", ".tab.features", ".tab.actions"];
         return foundry.utils.mergeObject(options, {
             classes: ["sfrpg", "sheet", "actor", "mech"],
             width: 700
@@ -247,6 +247,82 @@ export class ActorSheetSFRPGMech extends ActorSheetSFRPG {
         };
         data.hasLockerWeapons = lockerWeapons.length > 0;
 
+        // === Actions Tab Data ===
+        const actionsTab = {};
+
+        // Enabled weapons: mounted weapons (not in locker)
+        actionsTab.enabledWeapons = weapons.filter(w => w.system.slot !== "locker");
+
+        // PP Actions (universal, always available)
+        const currentPP = actorData.attributes?.pp?.value || 0;
+        const insufficientPPTooltip = game.i18n.localize("SFRPG.MechSheet.Actions.InsufficientPP");
+        actionsTab.ppActions = [
+            { name: game.i18n.localize("SFRPG.MechSheet.Actions.PP.Aim.Name"), description: game.i18n.localize("SFRPG.MechSheet.Actions.PP.Aim.Description"), ppCost: 1 },
+            { name: game.i18n.localize("SFRPG.MechSheet.Actions.PP.DevastatingHit.Name"), description: game.i18n.localize("SFRPG.MechSheet.Actions.PP.DevastatingHit.Description"), ppCost: 3 },
+            { name: game.i18n.localize("SFRPG.MechSheet.Actions.PP.Maneuver.Name"), description: game.i18n.localize("SFRPG.MechSheet.Actions.PP.Maneuver.Description"), ppCost: 1 },
+            { name: game.i18n.localize("SFRPG.MechSheet.Actions.PP.Replenish.Name"), description: game.i18n.localize("SFRPG.MechSheet.Actions.PP.Replenish.Description"), ppCost: 2 },
+            { name: game.i18n.localize("SFRPG.MechSheet.Actions.PP.Resist.Name"), description: game.i18n.localize("SFRPG.MechSheet.Actions.PP.Resist.Description"), ppCost: 1 }
+        ];
+        for (const action of actionsTab.ppActions) {
+            action.canAfford = currentPP >= action.ppCost;
+            action.insufficientPPTooltip = insufficientPPTooltip;
+        }
+
+        // Special Actions (universal, action type instead of PP cost)
+        const actionTypeLabels = {
+            standard: game.i18n.localize("SFRPG.MechSheet.Actions.ActionTypes.Standard"),
+            move: game.i18n.localize("SFRPG.MechSheet.Actions.ActionTypes.Move"),
+            full: game.i18n.localize("SFRPG.MechSheet.Actions.ActionTypes.Full"),
+            swift: game.i18n.localize("SFRPG.MechSheet.Actions.ActionTypes.Swift"),
+            reaction: game.i18n.localize("SFRPG.MechSheet.Actions.ActionTypes.Reaction")
+        };
+        const constantLabel = game.i18n.localize("SFRPG.MechSheet.Actions.ActionTypes.Constant");
+
+        actionsTab.specialActions = [
+            { name: game.i18n.localize("SFRPG.MechSheet.Actions.Special.CalledShot.Name"), description: game.i18n.localize("SFRPG.MechSheet.Actions.Special.CalledShot.Description"), actionType: "standard", actionTypeLabel: actionTypeLabels.standard },
+            { name: game.i18n.localize("SFRPG.MechSheet.Actions.Special.Hurl.Name"), description: game.i18n.localize("SFRPG.MechSheet.Actions.Special.Hurl.Description"), actionType: "full", actionTypeLabel: actionTypeLabels.full },
+            { name: game.i18n.localize("SFRPG.MechSheet.Actions.Special.Scan.Name"), description: game.i18n.localize("SFRPG.MechSheet.Actions.Special.Scan.Description"), actionType: "move", actionTypeLabel: actionTypeLabels.move }
+        ];
+
+        // Gear Actions: from equipped components that have actions arrays
+        actionsTab.gearActions = [];
+        const componentSources = [...weapons, ...lowerLimbs, ...upperLimbs, ...auxiliarySystems];
+        for (const component of componentSources) {
+            const actions = component.system.actions || [];
+            for (let i = 0; i < actions.length; i++) {
+                const action = actions[i];
+                if (!action.name) continue;
+
+                const hasPPCost = action.ppCost !== null && action.ppCost !== undefined;
+                let buttonLabel;
+                if (hasPPCost) {
+                    buttonLabel = `${action.ppCost} PP`;
+                } else if (action.actionType && actionTypeLabels[action.actionType]) {
+                    buttonLabel = actionTypeLabels[action.actionType];
+                } else {
+                    buttonLabel = constantLabel;
+                }
+
+                actionsTab.gearActions.push({
+                    actionName: action.name,
+                    gearName: component.name,
+                    displayName: `${action.name} (${component.name})`,
+                    description: action.description,
+                    ppCost: action.ppCost,
+                    actionType: action.actionType,
+                    buttonLabel: buttonLabel,
+                    hasPPCost: hasPPCost,
+                    canAfford: !hasPPCost || currentPP >= action.ppCost,
+                    insufficientPPTooltip: insufficientPPTooltip,
+                    itemId: component._id,
+                    actionIndex: i
+                });
+            }
+        }
+        actionsTab.gearActions.sort((a, b) => a.displayName.localeCompare(b.displayName));
+
+        data.actionsTab = actionsTab;
+
         // Mission pods data - sort alphabetically
         missionPods.sort((a, b) => a.name.localeCompare(b.name));
         const activePod = missionPods.find(p => p.system.isActive);
@@ -299,6 +375,11 @@ export class ActorSheetSFRPGMech extends ActorSheetSFRPG {
         // AC Adjustment Controls
         html.find('.ac-adjust').click(event => this._onACAdjust(event));
 
+        // Actions Tab - action buttons post to chat
+        html.find('.mech-pp-action').click(event => this._onMechAction(event, "pp"));
+        html.find('.mech-special-action').click(event => this._onMechAction(event, "special"));
+        html.find('.mech-gear-action').click(event => this._onMechAction(event, "gear"));
+
         // Mech weapon action button dragging (for creating hotbar macros)
         const attackButtons = html[0].querySelectorAll('button.attack, button.damage');
         for (const btn of attackButtons) {
@@ -349,6 +430,98 @@ export class ActorSheetSFRPGMech extends ActorSheetSFRPG {
         const current = foundry.utils.getProperty(this.actor, field) || 0;
         const newValue = action === "increase" ? current + 1 : current - 1;
         this.actor.update({ [field]: newValue });
+    }
+
+    /**
+     * Handle clicking a mech action button. Posts a chat card describing the action.
+     * @param {Event} event The click event
+     * @param {string} actionCategory "pp", "special", or "gear"
+     */
+    async _onMechAction(event, actionCategory) {
+        event.preventDefault();
+        const el = event.currentTarget;
+        const actionIndex = parseInt(el.dataset.actionIndex);
+
+        let name, description, ppCost, actionType, gearName, img;
+        img = this.actor.img;
+
+        if (actionCategory === "pp") {
+            const ppActions = [
+                { name: "SFRPG.MechSheet.Actions.PP.Aim.Name", desc: "SFRPG.MechSheet.Actions.PP.Aim.Description", ppCost: 1 },
+                { name: "SFRPG.MechSheet.Actions.PP.DevastatingHit.Name", desc: "SFRPG.MechSheet.Actions.PP.DevastatingHit.Description", ppCost: 3 },
+                { name: "SFRPG.MechSheet.Actions.PP.Maneuver.Name", desc: "SFRPG.MechSheet.Actions.PP.Maneuver.Description", ppCost: 1 },
+                { name: "SFRPG.MechSheet.Actions.PP.Replenish.Name", desc: "SFRPG.MechSheet.Actions.PP.Replenish.Description", ppCost: 2 },
+                { name: "SFRPG.MechSheet.Actions.PP.Resist.Name", desc: "SFRPG.MechSheet.Actions.PP.Resist.Description", ppCost: 1 }
+            ];
+            const action = ppActions[actionIndex];
+            name = game.i18n.localize(action.name);
+            description = game.i18n.localize(action.desc);
+            ppCost = action.ppCost;
+        } else if (actionCategory === "special") {
+            const specialActions = [
+                { name: "SFRPG.MechSheet.Actions.Special.CalledShot.Name", desc: "SFRPG.MechSheet.Actions.Special.CalledShot.Description", actionType: "standard" },
+                { name: "SFRPG.MechSheet.Actions.Special.Hurl.Name", desc: "SFRPG.MechSheet.Actions.Special.Hurl.Description", actionType: "full" },
+                { name: "SFRPG.MechSheet.Actions.Special.Scan.Name", desc: "SFRPG.MechSheet.Actions.Special.Scan.Description", actionType: "move" }
+            ];
+            const action = specialActions[actionIndex];
+            name = game.i18n.localize(action.name);
+            description = game.i18n.localize(action.desc);
+            actionType = action.actionType;
+        } else if (actionCategory === "gear") {
+            const itemId = el.dataset.itemId;
+            const itemActionIndex = parseInt(el.dataset.itemActionIndex);
+            const item = this.actor.items.get(itemId);
+            if (!item) return;
+            const action = item.system.actions?.[itemActionIndex];
+            if (!action) return;
+            name = `${action.name} (${item.name})`;
+            description = action.description;
+            ppCost = action.ppCost;
+            actionType = action.actionType;
+            gearName = item.name;
+            img = item.img;
+        }
+
+        const actionTypeLabels = {
+            standard: game.i18n.localize("SFRPG.MechSheet.Actions.ActionTypes.Standard"),
+            move: game.i18n.localize("SFRPG.MechSheet.Actions.ActionTypes.Move"),
+            full: game.i18n.localize("SFRPG.MechSheet.Actions.ActionTypes.Full"),
+            swift: game.i18n.localize("SFRPG.MechSheet.Actions.ActionTypes.Swift"),
+            reaction: game.i18n.localize("SFRPG.MechSheet.Actions.ActionTypes.Reaction")
+        };
+
+        // Deduct PP if this action has a cost
+        if (ppCost !== null && ppCost !== undefined && ppCost > 0) {
+            const currentPP = this.actor.system.attributes.pp.value || 0;
+            if (currentPP < ppCost) {
+                ui.notifications.warn(game.i18n.localize("SFRPG.MechSheet.Actions.InsufficientPP"));
+                return;
+            }
+            await this.actor.update({ "system.attributes.pp.value": currentPP - ppCost });
+        }
+
+        const ppSpent = (ppCost !== null && ppCost !== undefined && ppCost > 0)
+            ? game.i18n.format("SFRPG.MechSheet.Actions.PPSpent", { amount: ppCost })
+            : null;
+
+        const templateData = {
+            actor: this.actor,
+            name: name,
+            img: img,
+            description: description,
+            ppCost: ppCost !== null && ppCost !== undefined ? `${ppCost} PP` : null,
+            ppSpent: ppSpent,
+            actionTypeLabel: actionType ? (actionTypeLabels[actionType] || actionType) : null,
+            gearName: gearName || null
+        };
+
+        const html = await renderTemplate("systems/sfrpg/templates/chat/mech-action-card.hbs", templateData);
+        await ChatMessage.create({
+            user: game.user.id,
+            speaker: ChatMessage.getSpeaker({ actor: this.actor }),
+            content: html,
+            type: CONST.CHAT_MESSAGE_TYPES.OTHER
+        });
     }
 
     /**

--- a/src/module/data/item/base-item.mjs
+++ b/src/module/data/item/base-item.mjs
@@ -544,6 +544,33 @@ export default class SFRPGItemBase extends SFRPGDocumentBase {
         };
     }
 
+    static mechActionTemplate() {
+        return {
+            name: new fields.StringField({
+                initial: "",
+                blank: true,
+                label: "SFRPG.MechSheet.Action.Name"
+            }),
+            description: new fields.StringField({
+                initial: "",
+                blank: true,
+                label: "SFRPG.MechSheet.Action.Description"
+            }),
+            ppCost: new fields.NumberField({
+                initial: null,
+                min: 0,
+                integer: true,
+                nullable: true,
+                label: "SFRPG.MechSheet.Action.PpCost"
+            }),
+            actionType: new fields.StringField({
+                initial: "",
+                blank: true,
+                label: "SFRPG.MechSheet.Action.ActionType"
+            })
+        };
+    }
+
     static starshipBPTemplate() {
         return {
             cost: new fields.NumberField({

--- a/src/module/data/item/mechAuxiliary.mjs
+++ b/src/module/data/item/mechAuxiliary.mjs
@@ -35,7 +35,11 @@ export default class SFRPGItemMechAuxiliary extends SFRPGItemBase {
                 integer: true,
                 required: true,
                 label: "SFRPG.MechSheet.Auxiliary.MpCost"
-            })
+            }),
+            actions: new fields.ArrayField(
+                new fields.SchemaField(SFRPGItemBase.mechActionTemplate()),
+                { initial: [], required: true, label: "SFRPG.MechSheet.Action.Actions" }
+            )
         });
 
         return schema;

--- a/src/module/data/item/mechLowerLimb.mjs
+++ b/src/module/data/item/mechLowerLimb.mjs
@@ -82,7 +82,11 @@ export default class SFRPGItemMechLowerLimb extends SFRPGItemBase {
                 min: 0,
                 required: true,
                 label: "SFRPG.MechSheet.LowerLimb.MpCost"
-            })
+            }),
+            actions: new fields.ArrayField(
+                new fields.SchemaField(SFRPGItemBase.mechActionTemplate()),
+                { initial: [], required: true, label: "SFRPG.MechSheet.Action.Actions" }
+            )
         });
 
         return schema;

--- a/src/module/data/item/mechUpperLimb.mjs
+++ b/src/module/data/item/mechUpperLimb.mjs
@@ -77,7 +77,11 @@ export default class SFRPGItemMechUpperLimb extends SFRPGItemBase {
                 min: 0,
                 required: true,
                 label: "SFRPG.MechSheet.UpperLimb.MpCost"
-            })
+            }),
+            actions: new fields.ArrayField(
+                new fields.SchemaField(SFRPGItemBase.mechActionTemplate()),
+                { initial: [], required: true, label: "SFRPG.MechSheet.Action.Actions" }
+            )
         });
 
         return schema;

--- a/src/module/data/item/mechWeapon.mjs
+++ b/src/module/data/item/mechWeapon.mjs
@@ -107,7 +107,11 @@ export default class SFRPGItemMechWeapon extends SFRPGItemBase {
                 initial: "",
                 blank: true,
                 label: "SFRPG.MechSheet.Weapon.Special"
-            })
+            }),
+            actions: new fields.ArrayField(
+                new fields.SchemaField(SFRPGItemBase.mechActionTemplate()),
+                { initial: [], required: true, label: "SFRPG.MechSheet.Action.Actions" }
+            )
         });
 
         return schema;

--- a/src/module/item/sheet.js
+++ b/src/module/item/sheet.js
@@ -672,6 +672,9 @@ export class ItemSheetSFRPG extends foundry.appv1.sheets.ItemSheet {
 
         // Modify damage formula
         html.find(".damage-control").click(this._onDamageControl.bind(this));
+
+        // Modify mech actions array
+        html.find(".mech-action-control").click(this._onMechActionControl.bind(this));
         html.find("input.primary-section-checkbox").click(this._onTogglePrimaryDamageSection.bind(this));
         html.find(".visualization-control").click(this._onActorResourceVisualizationControl.bind(this));
         html.find(".ability-adjustments-control").click(this._onAbilityAdjustmentsControl.bind(this));
@@ -841,6 +844,29 @@ export class ItemSheetSFRPG extends foundry.appv1.sheets.ItemSheet {
             return this.item.update({
                 "system.critical.parts": criticalDamage.parts
             });
+        }
+    }
+
+    async _onMechActionControl(event) {
+        event.preventDefault();
+        const a = event.currentTarget;
+
+        if (a.classList.contains("add-action")) {
+            await this._onSubmit(event);
+            const actions = this.item.system.actions || [];
+            return this.item.update({
+                "system.actions": actions.concat([
+                    { name: "", description: "", ppCost: null, actionType: "" }
+                ])
+            });
+        }
+
+        if (a.classList.contains("delete-action")) {
+            await this._onSubmit(event);
+            const li = a.closest(".mech-action-entry");
+            const actions = foundry.utils.deepClone(this.item.system.actions || []);
+            actions.splice(Number(li.dataset.actionIndex), 1);
+            return this.item.update({ "system.actions": actions });
         }
     }
 

--- a/src/module/rules/actions/actor/mech/calculate-mech-components.js
+++ b/src/module/rules/actions/actor/mech/calculate-mech-components.js
@@ -427,6 +427,10 @@ export default function(engine) {
             }
         }
 
+        data.attributes.fort.bonus = data.attributes.fort.value;
+        data.attributes.ref.bonus = data.attributes.ref.value;
+        data.attributes.reflex = data.attributes.ref;
+
         return fact;
     });
 }

--- a/src/sfrpg.js
+++ b/src/sfrpg.js
@@ -838,6 +838,37 @@ Hooks.on("renderAbstractSidebarTab", async (app) => {
     }
 });
 
+Hooks.on("onAfterUpdateCombat", async (eventData) => {
+    if (!game.users.activeGM?.isSelf) return;
+    if (!eventData.isNewTurn || !eventData.newCombatant) return;
+
+    const actor = eventData.newCombatant.actor;
+    if (!actor || actor.type !== "mech") return;
+
+    const pp = actor.system.attributes.pp;
+    const regen = pp.regen || 0;
+    if (regen <= 0 || pp.value >= pp.max) return;
+
+    const oldValue = pp.value;
+    const newValue = Math.min(oldValue + regen, pp.max);
+    const gained = newValue - oldValue;
+
+    await actor.update({"system.attributes.pp.value": newValue});
+
+    const whisperTargets = game.users.filter(u => u.isGM || actor.testUserPermission(u, "OWNER")).map(u => u.id);
+
+    await ChatMessage.create({
+        speaker: ChatMessage.getSpeaker({actor: actor}),
+        content: game.i18n.format("SFRPG.MechSheet.Actions.PPRegenMessage", {
+            name: actor.name,
+            amount: gained,
+            current: newValue,
+            max: pp.max
+        }),
+        whisper: whisperTargets
+    });
+});
+
 // Set this hook up outside of init for the sake of module compatibility.
 Hooks.on("renderGamePause", () => {
     if (game.settings.get("sfrpg", "sfrpgTheme")) {

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -3309,6 +3309,7 @@
                 "UpperLimbs": "Upper Limbs"
             },
             "Tabs": {
+                "Actions": "Actions",
                 "Components": "Components",
                 "Operators": "Operators",
                 "Weapons": "Weapons",
@@ -3402,6 +3403,70 @@
                     "Speed": "Speed (ft.)"
                 },
                 "Contents": "Pod Contents"
+            },
+            "Action": {
+                "Actions": "Special Actions",
+                "Name": "Action Name",
+                "Description": "Description",
+                "PpCost": "PP Cost",
+                "ActionType": "Action Type",
+                "AddAction": "Add Action",
+                "RemoveAction": "Remove Action"
+            },
+            "Actions": {
+                "EnabledWeapons": "Enabled Weapons",
+                "PPActions": "PP Actions",
+                "SpecialActions": "Special Actions",
+                "GearActions": "Gear Actions",
+                "NoEnabledWeapons": "No weapons mounted",
+                "NoGearActions": "No gear actions available",
+                "InsufficientPP": "Insufficient Power Points to perform this action.",
+                "PPSpent": "{amount} PP spent",
+                "PPRegenMessage": "{name} regenerates {amount} PP ({current}/{max})",
+                "PP": {
+                    "Aim": {
+                        "Name": "Aim",
+                        "Description": "Before attempting an attack roll, roll 1d4 and add the result as an insight bonus to the attack roll."
+                    },
+                    "DevastatingHit": {
+                        "Name": "Devastating Hit",
+                        "Description": "After hitting a creature with an attack, but before dealing damage, increase the weapon's damage value by one step (e.g., medium damage instead deals high damage). A weapon that already deals extreme damage instead adds 1 additional damage for every damage die rolled. This can't be used for weapons that attack an intersection rather than a creature."
+                    },
+                    "Maneuver": {
+                        "Name": "Maneuver",
+                        "Description": "Choose one skill. Until the beginning of the mech's next turn, operators add any insight bonuses they have that apply to that skill to the mech's checks with that skill."
+                    },
+                    "Replenish": {
+                        "Name": "Replenish",
+                        "Description": "Activate when regaining Shield Points. The number of SP the mech recovers increases by 1d8. This increases by an additional 1d8 at tier 5 and every 5 tiers thereafter."
+                    },
+                    "Resist": {
+                        "Name": "Resist",
+                        "Description": "Before attempting a saving throw, roll 1d4 and add the result as a resistance bonus to the saving throw."
+                    }
+                },
+                "Special": {
+                    "CalledShot": {
+                        "Name": "Called Shot",
+                        "Description": "Expend 1 or 3 PP and make an attack against a single mech. If the attack's damage causes system damage, choose which component takes the damage (excluding power core or cockpit). If 3 PP were expended, any component can be selected."
+                    },
+                    "Hurl": {
+                        "Name": "Hurl",
+                        "Description": "Grab a nearby object and throw it as a ranged attack with a 30-foot range increment. The object can be at most two size categories smaller than the mech. Maximum or next-smallest size objects deal medium damage; smaller objects deal light damage. Throwing a creature or vehicle requires a successful grapple combat maneuver."
+                    },
+                    "Scan": {
+                        "Name": "Scan",
+                        "Description": "Use the sensor array to study one creature, mech, or object observed with a precise sense. Against a creature, this functions as a check to identify using the mech's Computers bonus. Success also grants a +1 insight bonus to the next attack against that creature. Against a mech or object, a Computers check reveals information about it. Each additional scan of the same target within an hour costs 1 PP per previous attempt."
+                    }
+                },
+                "ActionTypes": {
+                    "Standard": "Standard",
+                    "Move": "Move",
+                    "Full": "Full",
+                    "Swift": "Swift",
+                    "Reaction": "Reaction",
+                    "Constant": "Constant"
+                }
             },
             "Weapon": {
                 "Area": "Area",

--- a/static/templates/actors/mech-sheet-full.hbs
+++ b/static/templates/actors/mech-sheet-full.hbs
@@ -37,6 +37,7 @@
     <nav class="sheet-navigation tabs" data-group="primary">
         <a class="item active" data-tab="details">{{ localize "SFRPG.Details" }}</a>
         <a class="item" data-tab="components">{{ localize "SFRPG.MechSheet.Tabs.Components" }}</a>
+        <a class="item" data-tab="actions">{{ localize "SFRPG.MechSheet.Tabs.Actions" }}</a>
         {{#if hasLockerWeapons}}<a class="item" data-tab="weapons-locker">{{ localize "SFRPG.MechSheet.Tabs.WeaponsLocker" }}</a>{{/if}}
         <a class="item" data-tab="operators">{{ localize "SFRPG.MechSheet.Tabs.Operators" }}</a>
         <a class="item" data-tab="notes">{{ localize "SFRPG.Notes" }}</a>
@@ -88,14 +89,14 @@
                             <span class="calculated-value">{{numberFormat system.attributes.init.total sign=true}}</span>
                         </div>
                     </li>
-                    <li class="attribute" data-tooltip="{{#each system.attributes.fort.tooltip as |tip|}}{{tip}}<br>{{/each}}">
-                        <h4 class="attribute-name box-title">{{ localize "SFRPG.FortitudeSave" }}</h4>
+                    <li class="attribute save" data-save="fort" data-tooltip="{{#each system.attributes.fort.tooltip as |tip|}}{{tip}}<br>{{/each}}">
+                        <h4 class="attribute-name save-name box-title rollable">{{ localize "SFRPG.FortitudeSave" }}</h4>
                         <div class="attribute-value">
                             <span class="calculated-value">+{{system.attributes.fort.value}}</span>
                         </div>
                     </li>
-                    <li class="attribute" data-tooltip="{{#each system.attributes.ref.tooltip as |tip|}}{{tip}}<br>{{/each}}">
-                        <h4 class="attribute-name box-title">{{ localize "SFRPG.ReflexSave" }}</h4>
+                    <li class="attribute save" data-save="reflex" data-tooltip="{{#each system.attributes.ref.tooltip as |tip|}}{{tip}}<br>{{/each}}">
+                        <h4 class="attribute-name save-name box-title rollable">{{ localize "SFRPG.ReflexSave" }}</h4>
                         <div class="attribute-value">
                             <span class="calculated-value">+{{system.attributes.ref.value}}</span>
                         </div>
@@ -451,6 +452,111 @@
                 {{/if}}
             </ol>
             {{/each}}
+        </div>
+
+        {{!-- Actions Tab --}}
+        <div class="tab actions flexcol" data-group="primary" data-tab="actions">
+
+            {{!-- Enabled Weapons --}}
+            <ol class="mech-action-list">
+                <li class="mech-action-header flexrow">
+                    <h3 class="item-name noborder">{{ localize "SFRPG.MechSheet.Actions.EnabledWeapons" }}</h3>
+                </li>
+                {{#if actionsTab.enabledWeapons.length}}
+                {{#each actionsTab.enabledWeapons as |weapon|}}
+                <li class="mech-action-item flexrow item" data-item-id="{{weapon._id}}">
+                    <div class="mech-action-name flexrow">
+                        <div class="item-image small" style="background-image: url({{weapon.img}})"></div>
+                        <h4 class="rollable">{{weapon.name}}</h4>
+                    </div>
+                    {{#if @root.isOwner}}
+                    <div class="mech-action-buttons item-action">
+                        {{#if weapon.config.hasAttack}}
+                        <button type="button" class="tag attack" data-tooltip="{{weapon.config.attackTooltip}}">
+                            {{weapon.config.attackString}}
+                        </button>
+                        {{/if}}
+                        {{#if weapon.config.hasDamage}}
+                        <button type="button" class="tag damage" data-tooltip="{{localize "SFRPG.Damage.Title"}}">
+                            {{weapon.config.damageString}}
+                        </button>
+                        {{/if}}
+                    </div>
+                    {{/if}}
+                </li>
+                {{/each}}
+                {{else}}
+                <li class="mech-action-item flexrow empty-slot">
+                    <span>{{ localize "SFRPG.MechSheet.Actions.NoEnabledWeapons" }}</span>
+                </li>
+                {{/if}}
+            </ol>
+
+            {{!-- PP Actions --}}
+            <ol class="mech-action-list">
+                <li class="mech-action-header flexrow">
+                    <h3 class="item-name noborder">{{ localize "SFRPG.MechSheet.Actions.PPActions" }}</h3>
+                </li>
+                {{#each actionsTab.ppActions as |action|}}
+                <li class="mech-action-item flexrow">
+                    <div class="mech-action-name" data-tooltip="{{action.description}}">
+                        <h4>{{action.name}}</h4>
+                    </div>
+                    {{#if @root.isOwner}}
+                    <div class="mech-action-buttons">
+                        <button type="button" class="tag mech-pp-action pp-cost-button{{#unless action.canAfford}} disabled{{/unless}}" data-action-index="{{@index}}" {{#unless action.canAfford}}disabled data-tooltip="{{action.insufficientPPTooltip}}"{{/unless}}>
+                            {{action.ppCost}} PP
+                        </button>
+                    </div>
+                    {{/if}}
+                </li>
+                {{/each}}
+            </ol>
+
+            {{!-- Special Actions --}}
+            <ol class="mech-action-list">
+                <li class="mech-action-header flexrow">
+                    <h3 class="item-name noborder">{{ localize "SFRPG.MechSheet.Actions.SpecialActions" }}</h3>
+                </li>
+                {{#each actionsTab.specialActions as |action|}}
+                <li class="mech-action-item flexrow">
+                    <div class="mech-action-name" data-tooltip="{{action.description}}">
+                        <h4>{{action.name}}</h4>
+                    </div>
+                    {{#if @root.isOwner}}
+                    <div class="mech-action-buttons">
+                        <button type="button" class="tag mech-special-action action-type-button" data-action-index="{{@index}}">
+                            {{action.actionTypeLabel}}
+                        </button>
+                    </div>
+                    {{/if}}
+                </li>
+                {{/each}}
+            </ol>
+
+            {{!-- Gear Actions --}}
+            {{#if actionsTab.gearActions.length}}
+            <ol class="mech-action-list">
+                <li class="mech-action-header flexrow">
+                    <h3 class="item-name noborder">{{ localize "SFRPG.MechSheet.Actions.GearActions" }}</h3>
+                </li>
+                {{#each actionsTab.gearActions as |action|}}
+                <li class="mech-action-item flexrow">
+                    <div class="mech-action-name" data-tooltip="{{action.description}}">
+                        <h4>{{action.displayName}}</h4>
+                    </div>
+                    {{#if @root.isOwner}}
+                    <div class="mech-action-buttons">
+                        <button type="button" class="tag mech-gear-action {{#if action.hasPPCost}}pp-cost-button{{else}}action-type-button{{/if}}{{#unless action.canAfford}} disabled{{/unless}}" data-item-id="{{action.itemId}}" data-item-action-index="{{action.actionIndex}}" data-action-index="{{@index}}" {{#unless action.canAfford}}disabled data-tooltip="{{action.insufficientPPTooltip}}"{{/unless}}>
+                            {{action.buttonLabel}}
+                        </button>
+                    </div>
+                    {{/if}}
+                </li>
+                {{/each}}
+            </ol>
+            {{/if}}
+
         </div>
 
         {{!-- Weapons Locker Tab --}}

--- a/static/templates/actors/parts/actor-features-item.hbs
+++ b/static/templates/actors/parts/actor-features-item.hbs
@@ -30,7 +30,7 @@
                 {{#if (or item.config.hasAttack item.config.hasDamage)}}
                 <div class="item-action flexcol">
                     {{#if item.config.hasAttack}}
-                    <button type="button" class="tag attack" data-tooltip="{{localize "SFRPG.Attack"}}">{{item.config.attackString}}</button>
+                    <button type="button" class="tag attack" data-tooltip="{{#if item.config.attackTooltip}}{{item.config.attackTooltip}}{{else}}{{localize "SFRPG.Attack"}}{{/if}}">{{item.config.attackString}}</button>
                     {{/if}}
                     {{#if item.config.hasDamage}}
                         {{#if (eq item.system.actionType "heal")}}

--- a/static/templates/actors/parts/actor-inventory-item.hbs
+++ b/static/templates/actors/parts/actor-inventory-item.hbs
@@ -13,7 +13,7 @@
                 <div class="item-action {{#if item.parentItem}}flexrow flexnowrap{{else}}flexcol{{/if}}">
                     {{#if (or item.config.hasAttack item.config.hasDamage)}}
                         {{#if item.config.hasAttack}}
-                        <button type="button" class="tag attack" data-tooltip="{{localize "SFRPG.Attack"}}">{{item.config.attackString}}</button>
+                        <button type="button" class="tag attack" data-tooltip="{{#if item.config.attackTooltip}}{{item.config.attackTooltip}}{{else}}{{localize "SFRPG.Attack"}}{{/if}}">{{item.config.attackString}}</button>
                         {{/if}}
                         {{#if (and item.config.hasDamage (not (eq item.type "consumable")))}}
                             {{#if (eq item.system.actionType "heal")}}

--- a/static/templates/chat/mech-action-card.hbs
+++ b/static/templates/chat/mech-action-card.hbs
@@ -1,0 +1,17 @@
+<div class="sfrpg chat-card mech-action-card" data-actor-id="{{actor.id}}">
+    <header class="card-header flexrow">
+        <img class="action-img" src="{{img}}" title="{{name}}" width="36" height="36" />
+        <h3 class="action-name">{{name}}</h3>
+    </header>
+    <div class="card-content">
+        <p>{{description}}</p>
+    </div>
+    {{#if actionTypeLabel}}
+    <footer class="card-footer">
+        <span class="tag">{{actionTypeLabel}}</span>
+    </footer>
+    {{/if}}
+    {{#if ppSpent}}
+    <div class="card-pp-spent">{{ppSpent}}</div>
+    {{/if}}
+</div>

--- a/static/templates/items/mechAuxiliary.hbs
+++ b/static/templates/items/mechAuxiliary.hbs
@@ -78,6 +78,17 @@
                 </div>
             </div>
 
+            {{!-- Special Actions --}}
+            <div class="bubble">
+                <h4 class="bubble-header">
+                    {{ localize "SFRPG.MechSheet.Action.Actions" }}
+                    <a class="mech-action-control add-action bubble-icon"><i class="fas fa-plus"></i></a>
+                </h4>
+                <div class="bubble-info">
+                    {{> "systems/sfrpg/templates/items/parts/mech-actions.hbs"}}
+                </div>
+            </div>
+
         </div>
 
     </section>

--- a/static/templates/items/mechLowerLimb.hbs
+++ b/static/templates/items/mechLowerLimb.hbs
@@ -124,6 +124,17 @@
                 </div>
             </div>
 
+            {{!-- Special Actions --}}
+            <div class="bubble">
+                <h4 class="bubble-header">
+                    {{ localize "SFRPG.MechSheet.Action.Actions" }}
+                    <a class="mech-action-control add-action bubble-icon"><i class="fas fa-plus"></i></a>
+                </h4>
+                <div class="bubble-info">
+                    {{> "systems/sfrpg/templates/items/parts/mech-actions.hbs"}}
+                </div>
+            </div>
+
         </div>
 
     </section>

--- a/static/templates/items/mechUpperLimb.hbs
+++ b/static/templates/items/mechUpperLimb.hbs
@@ -118,6 +118,17 @@
                 </div>
             </div>
 
+            {{!-- Special Actions --}}
+            <div class="bubble">
+                <h4 class="bubble-header">
+                    {{ localize "SFRPG.MechSheet.Action.Actions" }}
+                    <a class="mech-action-control add-action bubble-icon"><i class="fas fa-plus"></i></a>
+                </h4>
+                <div class="bubble-info">
+                    {{> "systems/sfrpg/templates/items/parts/mech-actions.hbs"}}
+                </div>
+            </div>
+
         </div>
 
     </section>

--- a/static/templates/items/mechWeapon.hbs
+++ b/static/templates/items/mechWeapon.hbs
@@ -154,6 +154,17 @@
                 </div>
             </div>
 
+            {{!-- Special Actions --}}
+            <div class="bubble">
+                <h4 class="bubble-header">
+                    {{ localize "SFRPG.MechSheet.Action.Actions" }}
+                    <a class="mech-action-control add-action bubble-icon"><i class="fas fa-plus"></i></a>
+                </h4>
+                <div class="bubble-info">
+                    {{> "systems/sfrpg/templates/items/parts/mech-actions.hbs"}}
+                </div>
+            </div>
+
         </div>
 
     </section>


### PR DESCRIPTION
## Summary
- Adds an **Actions tab** to the mech actor sheet with four sections: enabled weapon attacks, 5 universal PP actions (Aim, Devastating Hit, Maneuver, Replenish, Resist), 3 special actions (Called Shot, Hurl, Scan), and gear-specific actions from equipped components
- **PP actions deduct Power Points** on click with validation (greyed out when insufficient PP), and post chat cards noting PP spent
- **Attack buttons show computed totals** including best operator bonus (max of BAB or Piloting ranks), with tooltip breakdown of contributing factors
- **Fortitude and Reflex saves** are now clickable/rollable on the mech Details tab
- **Automatic PP regeneration** at the start of a mech's combat turn via the `onAfterUpdateCombat` hook, with whispered chat notification to player and GM
- Adds `actions` array field to mech component data models (mechWeapon, mechAuxiliary, mechLowerLimb, mechUpperLimb) with item sheet editing UI
- Populates compendium JSON for 26 mech components with structured action data
- Includes chat card template, LESS styles, and full localization

## Test plan
- [ ] Actions tab appears on mech sheet with correct sections
- [ ] Weapon attack/damage buttons work and show computed totals with tooltip
- [ ] PP actions deduct PP, show "X PP spent" in chat, and grey out when insufficient
- [ ] Special actions and gear actions post chat cards correctly
- [ ] Fortitude and Reflex saves roll when clicked on the Details tab
- [ ] PP regenerates at start of mech's combat turn (linked token required)
- [ ] Whispered chat message appears for PP regen (visible to owner and GM only)
- [ ] Item sheets allow adding/removing actions on mech components
- [ ] Compendium items load with pre-populated actions

Closes #11