### PR TITLE
Add power core templates

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -3342,11 +3342,63 @@
             },
             "PowerCore": {
                 "Title": "Power Core",
+                "CoreType": "Core Type",
+                "CoreTypes": {
+                    "Dynamo": "Dynamo",
+                    "Eternal": "Eternal"
+                },
                 "PPInitial": "Initial PP",
                 "PPMax": "Maximum PP",
                 "PPRegen": "PP Regen/Turn",
                 "MpCost": "MP Cost",
-                "OnlyOne": "A mech can only have one power core."
+                "OnlyOne": "A mech can only have one power core.",
+                "Template": "Template",
+                "TemplateNone": "None",
+                "TemplatePPModifiers": "PP Modifiers",
+                "TemplateMpCost": "Template MP Cost",
+                "TemplateTier": "Tier",
+                "TemplateRestriction": "Restriction",
+                "TemplateRestrictionError": "This template requires: {requirement}",
+                "RestrictionEternal": "Eternal core only",
+                "RestrictionRateAbove1": "PP Regen/Turn greater than 1",
+                "Templates": {
+                    "Aeon": {
+                        "Name": "Aeon",
+                        "Description": "Operators can expend unused spell slots to grant PP equal to half the slot level (rounded down), once per round."
+                    },
+                    "Battle": {
+                        "Name": "Battle",
+                        "Description": "Optimized for combat, this template sacrifices regeneration rate for increased maximum capacity."
+                    },
+                    "Corpsegnawer": {
+                        "Name": "Corpsegnawer",
+                        "Description": "The mech can draw life energy from nearby corpses to boost its power regeneration rate.",
+                        "ActionName": "Draw Life Energy",
+                        "ActionDescription": "As a standard action, draw life energy from corpses within reach (dead no more than 1 minute). Increases PP regen rate by 1 for 1 round per 4 levels/CR of the creature. Creature must be at least half the mech's tier."
+                    },
+                    "Scrapper": {
+                        "Name": "Scrapper",
+                        "Description": "The mech gains 1d4 PP whenever it receives a system failure condition. Excess PP beyond maximum are lost after the next turn."
+                    },
+                    "Archadrenal": {
+                        "Name": "Archadrenal",
+                        "Description": "The mech can convert its own structural integrity into power, taking damage to generate PP.",
+                        "ActionName": "Convert HP to PP",
+                        "ActionDescription": "As a free action, take 3 × tier HP damage (unmitigated, but heals normally) to gain 1 PP."
+                    },
+                    "ArtificialInfandibulum": {
+                        "Name": "Artificial Infandibulum",
+                        "Description": "All weapons count as magical. Ammunition can be reloaded via PP. Energy weapons can activate twice per round and can switch damage types (fire/electricity/sonic). Energy weapon hits create a gravitation effect (Reflex DC 10 + half tier + STR mod, 20-ft push on hit).",
+                        "ReloadActionName": "Reload Ammunition",
+                        "ReloadActionDescription": "Spend 2 or more PP to reload ammunition for a mech weapon.",
+                        "DoubleFireActionName": "Double Fire (Energy)",
+                        "DoubleFireActionDescription": "Energy weapons can activate a second time per round (second activation deals lower damage tier). Can switch energy damage type to fire, electricity, or sonic."
+                    },
+                    "Concerto": {
+                        "Name": "Concerto",
+                        "Description": "Profession (musician) replaces standard operation checks (except scanning and repair). The mech gains a roadie operator who provides one additional action per round."
+                    }
+                }
             },
             "LowerLimb": {
                 "Title": "Lower Limb",

--- a/src/items/mech-components/dynamo_core_mk_0.json
+++ b/src/items/mech-components/dynamo_core_mk_0.json
@@ -5,6 +5,7 @@
   "folder": "mCSahqNlZvTowXgu",
   "img": "systems/sfrpg/icons/default/power-generator.svg",
   "system": {
+    "coreType": "dynamo",
     "description": {
       "chat": "",
       "gmnotes": "",
@@ -16,6 +17,7 @@
     "ppInitial": 0,
     "ppMax": 5,
     "ppRegen": 2,
-    "source": "Tech Revolution pg. 109"
+    "source": "Tech Revolution pg. 109",
+    "template": ""
   }
 }

--- a/src/items/mech-components/dynamo_core_mk_1.json
+++ b/src/items/mech-components/dynamo_core_mk_1.json
@@ -5,6 +5,7 @@
   "folder": "mCSahqNlZvTowXgu",
   "img": "systems/sfrpg/icons/default/power-generator.svg",
   "system": {
+    "coreType": "dynamo",
     "description": {
       "chat": "",
       "gmnotes": "",
@@ -16,6 +17,7 @@
     "ppInitial": 1,
     "ppMax": 6,
     "ppRegen": 2,
-    "source": "Tech Revolution pg. 109"
+    "source": "Tech Revolution pg. 109",
+    "template": ""
   }
 }

--- a/src/items/mech-components/dynamo_core_mk_2.json
+++ b/src/items/mech-components/dynamo_core_mk_2.json
@@ -5,6 +5,7 @@
   "folder": "mCSahqNlZvTowXgu",
   "img": "systems/sfrpg/icons/default/power-generator.svg",
   "system": {
+    "coreType": "dynamo",
     "description": {
       "chat": "",
       "gmnotes": "",
@@ -16,6 +17,7 @@
     "ppInitial": 1,
     "ppMax": 7,
     "ppRegen": 3,
-    "source": "Tech Revolution pg. 109"
+    "source": "Tech Revolution pg. 109",
+    "template": ""
   }
 }

--- a/src/items/mech-components/dynamo_core_mk_3.json
+++ b/src/items/mech-components/dynamo_core_mk_3.json
@@ -5,6 +5,7 @@
   "folder": "mCSahqNlZvTowXgu",
   "img": "systems/sfrpg/icons/default/power-generator.svg",
   "system": {
+    "coreType": "dynamo",
     "description": {
       "chat": "",
       "gmnotes": "",
@@ -16,6 +17,7 @@
     "ppInitial": 2,
     "ppMax": 8,
     "ppRegen": 3,
-    "source": "Tech Revolution pg. 109"
+    "source": "Tech Revolution pg. 109",
+    "template": ""
   }
 }

--- a/src/items/mech-components/dynamo_core_mk_4.json
+++ b/src/items/mech-components/dynamo_core_mk_4.json
@@ -5,6 +5,7 @@
   "folder": "mCSahqNlZvTowXgu",
   "img": "systems/sfrpg/icons/default/power-generator.svg",
   "system": {
+    "coreType": "dynamo",
     "description": {
       "chat": "",
       "gmnotes": "",
@@ -16,6 +17,7 @@
     "ppInitial": 3,
     "ppMax": 9,
     "ppRegen": 4,
-    "source": "Tech Revolution pg. 109"
+    "source": "Tech Revolution pg. 109",
+    "template": ""
   }
 }

--- a/src/items/mech-components/eternal_core_mk_0.json
+++ b/src/items/mech-components/eternal_core_mk_0.json
@@ -5,6 +5,7 @@
   "folder": "mCSahqNlZvTowXgu",
   "img": "systems/sfrpg/icons/default/power-generator.svg",
   "system": {
+    "coreType": "eternal",
     "description": {
       "chat": "",
       "gmnotes": "",
@@ -16,6 +17,7 @@
     "ppInitial": 4,
     "ppMax": 8,
     "ppRegen": 1,
-    "source": "Tech Revolution pg. 109"
+    "source": "Tech Revolution pg. 109",
+    "template": ""
   }
 }

--- a/src/items/mech-components/eternal_core_mk_1.json
+++ b/src/items/mech-components/eternal_core_mk_1.json
@@ -5,6 +5,7 @@
   "folder": "mCSahqNlZvTowXgu",
   "img": "systems/sfrpg/icons/default/power-generator.svg",
   "system": {
+    "coreType": "eternal",
     "description": {
       "chat": "",
       "gmnotes": "",
@@ -16,6 +17,7 @@
     "ppInitial": 5,
     "ppMax": 10,
     "ppRegen": 1,
-    "source": "Tech Revolution pg. 109"
+    "source": "Tech Revolution pg. 109",
+    "template": ""
   }
 }

--- a/src/items/mech-components/eternal_core_mk_2.json
+++ b/src/items/mech-components/eternal_core_mk_2.json
@@ -5,6 +5,7 @@
   "folder": "mCSahqNlZvTowXgu",
   "img": "systems/sfrpg/icons/default/power-generator.svg",
   "system": {
+    "coreType": "eternal",
     "description": {
       "chat": "",
       "gmnotes": "",
@@ -16,6 +17,7 @@
     "ppInitial": 6,
     "ppMax": 13,
     "ppRegen": 1,
-    "source": "Tech Revolution pg. 109"
+    "source": "Tech Revolution pg. 109",
+    "template": ""
   }
 }

--- a/src/items/mech-components/eternal_core_mk_3.json
+++ b/src/items/mech-components/eternal_core_mk_3.json
@@ -5,6 +5,7 @@
   "folder": "mCSahqNlZvTowXgu",
   "img": "systems/sfrpg/icons/default/power-generator.svg",
   "system": {
+    "coreType": "eternal",
     "description": {
       "chat": "",
       "gmnotes": "",
@@ -16,6 +17,7 @@
     "ppInitial": 7,
     "ppMax": 15,
     "ppRegen": 2,
-    "source": "Tech Revolution pg. 109"
+    "source": "Tech Revolution pg. 109",
+    "template": ""
   }
 }

--- a/src/items/mech-components/eternal_core_mk_4.json
+++ b/src/items/mech-components/eternal_core_mk_4.json
@@ -5,6 +5,7 @@
   "folder": "mCSahqNlZvTowXgu",
   "img": "systems/sfrpg/icons/default/power-generator.svg",
   "system": {
+    "coreType": "eternal",
     "description": {
       "chat": "",
       "gmnotes": "",
@@ -16,6 +17,7 @@
     "ppInitial": 9,
     "ppMax": 18,
     "ppRegen": 2,
-    "source": "Tech Revolution pg. 109"
+    "source": "Tech Revolution pg. 109",
+    "template": ""
   }
 }

--- a/src/less/items.less
+++ b/src/less/items.less
@@ -640,4 +640,34 @@
             }
         }
     }
+
+    /* ----------------------------------------- */
+    /*  Power Core Template Info                 */
+    /* ----------------------------------------- */
+
+    .template-info {
+        margin-top: 4px;
+        padding: 4px 6px;
+        background: rgba(0, 0, 0, 0.04);
+        border-radius: 3px;
+
+        .template-description {
+            font-style: italic;
+            font-size: var(--font-size-12);
+            margin: 0 0 4px 0;
+        }
+
+        .template-modifiers .form-group {
+            margin-bottom: 2px;
+
+            label {
+                font-weight: bold;
+                flex: 0 0 120px;
+            }
+
+            span {
+                font-size: var(--font-size-12);
+            }
+        }
+    }
 }

--- a/src/module/actor/sheet/mech.js
+++ b/src/module/actor/sheet/mech.js
@@ -286,7 +286,7 @@ export class ActorSheetSFRPGMech extends ActorSheetSFRPG {
 
         // Gear Actions: from equipped components that have actions arrays
         actionsTab.gearActions = [];
-        const componentSources = [...weapons, ...lowerLimbs, ...upperLimbs, ...auxiliarySystems];
+        const componentSources = [...weapons, ...lowerLimbs, ...upperLimbs, ...auxiliarySystems, ...powerCores];
         for (const component of componentSources) {
             const actions = component.system.actions || [];
             for (let i = 0; i < actions.length; i++) {
@@ -319,6 +319,43 @@ export class ActorSheetSFRPGMech extends ActorSheetSFRPG {
                 });
             }
         }
+        // Power core template actions (from CONFIG)
+        for (const core of powerCores) {
+            const templateKey = core.system.template;
+            if (!templateKey) continue;
+            const templateData = CONFIG.SFRPG.mechPowerCoreTemplates[templateKey];
+            if (!templateData?.actions?.length) continue;
+
+            const templateLabel = game.i18n.localize(templateData.label);
+            for (const tAction of templateData.actions) {
+                const actionName = game.i18n.localize(tAction.name);
+                const hasPPCost = tAction.ppCost !== null && tAction.ppCost !== undefined;
+                let buttonLabel;
+                if (hasPPCost) {
+                    buttonLabel = `${tAction.ppCost} PP`;
+                } else if (tAction.actionType && actionTypeLabels[tAction.actionType]) {
+                    buttonLabel = actionTypeLabels[tAction.actionType];
+                } else {
+                    buttonLabel = constantLabel;
+                }
+
+                actionsTab.gearActions.push({
+                    actionName: actionName,
+                    gearName: `${core.name} (${templateLabel})`,
+                    displayName: `${actionName} (${core.name})`,
+                    description: game.i18n.localize(tAction.description),
+                    ppCost: tAction.ppCost,
+                    actionType: tAction.actionType,
+                    buttonLabel: buttonLabel,
+                    hasPPCost: hasPPCost,
+                    canAfford: !hasPPCost || currentPP >= tAction.ppCost,
+                    insufficientPPTooltip: insufficientPPTooltip,
+                    itemId: core._id,
+                    actionIndex: -1
+                });
+            }
+        }
+
         actionsTab.gearActions.sort((a, b) => a.displayName.localeCompare(b.displayName));
 
         data.actionsTab = actionsTab;

--- a/src/module/config.js
+++ b/src/module/config.js
@@ -1034,6 +1034,128 @@ SFRPG.mechStatsByTier = {
     20: { sp: 43, hardnessBonus: 10, baseAC: 38, baseSaveBonus: 17, baseAttackBonus: 12, strengthMod: 6 }
 };
 
+SFRPG.mechCoreTypes = {
+    "dynamo": "SFRPG.MechSheet.PowerCore.CoreTypes.Dynamo",
+    "eternal": "SFRPG.MechSheet.PowerCore.CoreTypes.Eternal"
+};
+
+SFRPG.mechPowerCoreTemplates = {
+    "aeon": {
+        label: "SFRPG.MechSheet.PowerCore.Templates.Aeon.Name",
+        description: "SFRPG.MechSheet.PowerCore.Templates.Aeon.Description",
+        restriction: "eternal",
+        ppRateMod: 0,
+        ppInitialMod: -1,
+        ppMaxMod: -1,
+        mpCostMultiplier: 0,
+        source: "Tech Revolution pg. 102",
+        actions: []
+    },
+    "battle": {
+        label: "SFRPG.MechSheet.PowerCore.Templates.Battle.Name",
+        description: "SFRPG.MechSheet.PowerCore.Templates.Battle.Description",
+        restriction: "rateAbove1",
+        ppRateMod: -1,
+        ppInitialMod: 0,
+        ppMaxMod: 1,
+        mpCostMultiplier: 0.5,
+        source: "Tech Revolution pg. 102",
+        actions: []
+    },
+    "corpsegnawer": {
+        label: "SFRPG.MechSheet.PowerCore.Templates.Corpsegnawer.Name",
+        description: "SFRPG.MechSheet.PowerCore.Templates.Corpsegnawer.Description",
+        restriction: null,
+        ppRateMod: 0,
+        ppInitialMod: 0,
+        ppMaxMod: 0,
+        mpCostMultiplier: 0.5,
+        source: "Tech Revolution pg. 102",
+        actions: [
+            {
+                name: "SFRPG.MechSheet.PowerCore.Templates.Corpsegnawer.ActionName",
+                description: "SFRPG.MechSheet.PowerCore.Templates.Corpsegnawer.ActionDescription",
+                ppCost: null,
+                actionType: "standard"
+            }
+        ]
+    },
+    "scrapper": {
+        label: "SFRPG.MechSheet.PowerCore.Templates.Scrapper.Name",
+        description: "SFRPG.MechSheet.PowerCore.Templates.Scrapper.Description",
+        restriction: null,
+        ppRateMod: 0,
+        ppInitialMod: 0,
+        ppMaxMod: 0,
+        mpCostMultiplier: 1,
+        source: "Tech Revolution pg. 102",
+        actions: []
+    },
+    "archadrenal": {
+        label: "SFRPG.MechSheet.PowerCore.Templates.Archadrenal.Name",
+        description: "SFRPG.MechSheet.PowerCore.Templates.Archadrenal.Description",
+        restriction: "rateAbove1",
+        ppRateMod: 0,
+        ppInitialMod: -1,
+        ppMaxMod: 0,
+        mpCostMultiplier: 0.5,
+        source: "Mechageddon! pg. 152",
+        actions: [
+            {
+                name: "SFRPG.MechSheet.PowerCore.Templates.Archadrenal.ActionName",
+                description: "SFRPG.MechSheet.PowerCore.Templates.Archadrenal.ActionDescription",
+                ppCost: null,
+                actionType: "free"
+            }
+        ]
+    },
+    "artificialInfandibulum": {
+        label: "SFRPG.MechSheet.PowerCore.Templates.ArtificialInfandibulum.Name",
+        description: "SFRPG.MechSheet.PowerCore.Templates.ArtificialInfandibulum.Description",
+        restriction: "eternal",
+        ppRateMod: 0,
+        ppInitialMod: -1,
+        ppMaxMod: -1,
+        mpCostMultiplier: 2,
+        source: "Mechageddon! pg. 152",
+        actions: [
+            {
+                name: "SFRPG.MechSheet.PowerCore.Templates.ArtificialInfandibulum.ReloadActionName",
+                description: "SFRPG.MechSheet.PowerCore.Templates.ArtificialInfandibulum.ReloadActionDescription",
+                ppCost: 2,
+                actionType: ""
+            },
+            {
+                name: "SFRPG.MechSheet.PowerCore.Templates.ArtificialInfandibulum.DoubleFireActionName",
+                description: "SFRPG.MechSheet.PowerCore.Templates.ArtificialInfandibulum.DoubleFireActionDescription",
+                ppCost: null,
+                actionType: ""
+            }
+        ]
+    },
+    "concerto": {
+        label: "SFRPG.MechSheet.PowerCore.Templates.Concerto.Name",
+        description: "SFRPG.MechSheet.PowerCore.Templates.Concerto.Description",
+        restriction: null,
+        ppRateMod: 0,
+        ppInitialMod: 0,
+        ppMaxMod: 0,
+        mpCostMultiplier: 0.5,
+        source: "Mechageddon! pg. 152",
+        actions: []
+    }
+};
+
+SFRPG.mechPowerCoreTemplateChoices = {
+    "aeon": "SFRPG.MechSheet.PowerCore.Templates.Aeon.Name",
+    "battle": "SFRPG.MechSheet.PowerCore.Templates.Battle.Name",
+    "corpsegnawer": "SFRPG.MechSheet.PowerCore.Templates.Corpsegnawer.Name",
+    "scrapper": "SFRPG.MechSheet.PowerCore.Templates.Scrapper.Name",
+    "archadrenal": "SFRPG.MechSheet.PowerCore.Templates.Archadrenal.Name",
+    "artificialInfandibulum": "SFRPG.MechSheet.PowerCore.Templates.ArtificialInfandibulum.Name",
+    "concerto": "SFRPG.MechSheet.PowerCore.Templates.Concerto.Name"
+};
+
 SFRPG.mechWeaponDamageLevels = {
     "low": "SFRPG.MechSheet.Weapon.DamageLevelLow",
     "medium": "SFRPG.MechSheet.Weapon.DamageLevelMedium",

--- a/src/module/data/item/mechPowerCore.mjs
+++ b/src/module/data/item/mechPowerCore.mjs
@@ -13,6 +13,13 @@ export default class SFRPGItemMechPowerCore extends SFRPGItemBase {
         const schema = super.defineSchema();
 
         foundry.utils.mergeObject(schema, {
+            coreType: new fields.StringField({
+                initial: "dynamo",
+                blank: false,
+                choices: ["dynamo", "eternal"],
+                required: true,
+                label: "SFRPG.MechSheet.PowerCore.CoreType"
+            }),
             ppInitial: new fields.NumberField({
                 initial: 3,
                 min: 0,
@@ -40,6 +47,12 @@ export default class SFRPGItemMechPowerCore extends SFRPGItemBase {
                 integer: true,
                 required: true,
                 label: "SFRPG.MechSheet.PowerCore.MpCost"
+            }),
+            template: new fields.StringField({
+                initial: "",
+                blank: true,
+                required: false,
+                label: "SFRPG.MechSheet.PowerCore.Template"
             })
         });
 

--- a/src/module/item/sheet.js
+++ b/src/module/item/sheet.js
@@ -306,6 +306,34 @@ export class ItemSheetSFRPG extends foundry.appv1.sheets.ItemSheet {
             }
         }
 
+        if (data.item.type === "mechPowerCore" && data.itemData.template) {
+            const templateData = CONFIG.SFRPG.mechPowerCoreTemplates[data.itemData.template];
+            if (templateData) {
+                const mods = [];
+                if (templateData.ppRateMod) mods.push(`${game.i18n.localize("SFRPG.MechSheet.PowerCore.PPRegen")}: ${templateData.ppRateMod > 0 ? "+" : ""}${templateData.ppRateMod}`);
+                if (templateData.ppInitialMod) mods.push(`${game.i18n.localize("SFRPG.MechSheet.PowerCore.PPInitial")}: ${templateData.ppInitialMod > 0 ? "+" : ""}${templateData.ppInitialMod}`);
+                if (templateData.ppMaxMod) mods.push(`${game.i18n.localize("SFRPG.MechSheet.PowerCore.PPMax")}: ${templateData.ppMaxMod > 0 ? "+" : ""}${templateData.ppMaxMod}`);
+
+                let restrictionDisplay = "";
+                if (templateData.restriction === "eternal") {
+                    restrictionDisplay = game.i18n.localize("SFRPG.MechSheet.PowerCore.RestrictionEternal");
+                } else if (templateData.restriction === "rateAbove1") {
+                    restrictionDisplay = game.i18n.localize("SFRPG.MechSheet.PowerCore.RestrictionRateAbove1");
+                }
+
+                data.templateInfo = {
+                    description: game.i18n.localize(templateData.description),
+                    hasModifiers: mods.length > 0,
+                    modifierSummary: mods.join(", "),
+                    mpCostDisplay: templateData.mpCostMultiplier > 0
+                        ? `${templateData.mpCostMultiplier} × ${game.i18n.localize("SFRPG.MechSheet.PowerCore.TemplateTier")}`
+                        : "",
+                    restrictionDisplay: restrictionDisplay,
+                    source: templateData.source
+                };
+            }
+        }
+
         return data;
     }
 
@@ -652,6 +680,28 @@ export class ItemSheetSFRPG extends foundry.appv1.sheets.ItemSheet {
                 newValue = isDelta ? Number(oldValue) + Number(sanitizedInput) : Number(sanitizedInput);
             }
             formData["system.quantity"] = newValue;
+        }
+
+        // Validate power core template restrictions
+        if (this.item.type === "mechPowerCore" && formData["system.template"]) {
+            const templateKey = formData["system.template"];
+            const templateData = CONFIG.SFRPG.mechPowerCoreTemplates[templateKey];
+            if (templateData) {
+                const coreType = formData["system.coreType"] ?? this.item.system.coreType;
+                const ppRegen = formData["system.ppRegen"] ?? this.item.system.ppRegen;
+
+                if (templateData.restriction === "eternal" && coreType !== "eternal") {
+                    ui.notifications.error(game.i18n.format("SFRPG.MechSheet.PowerCore.TemplateRestrictionError", {
+                        requirement: game.i18n.localize("SFRPG.MechSheet.PowerCore.RestrictionEternal")
+                    }));
+                    formData["system.template"] = "";
+                } else if (templateData.restriction === "rateAbove1" && ppRegen <= 1) {
+                    ui.notifications.error(game.i18n.format("SFRPG.MechSheet.PowerCore.TemplateRestrictionError", {
+                        requirement: game.i18n.localize("SFRPG.MechSheet.PowerCore.RestrictionRateAbove1")
+                    }));
+                    formData["system.template"] = "";
+                }
+            }
         }
 
         // Update the Item

--- a/src/module/rules/actions/actor/mech/calculate-mech-components.js
+++ b/src/module/rules/actions/actor/mech/calculate-mech-components.js
@@ -217,12 +217,40 @@ export default function(engine) {
         }
 
         // ========================================
-        // Power Points: From power core
+        // Power Points: From power core + template modifiers
         // ========================================
         if (powerCore) {
             data.attributes.pp.initial = powerCore.system.ppInitial || 3;
             data.attributes.pp.max = powerCore.system.ppMax || 5;
             data.attributes.pp.regen = powerCore.system.ppRegen || 1;
+
+            const templateKey = powerCore.system.template;
+            if (templateKey) {
+                const templateData = CONFIG.SFRPG.mechPowerCoreTemplates[templateKey];
+                if (templateData) {
+                    const templateLabel = game.i18n.localize(templateData.label);
+
+                    if (templateData.ppInitialMod) {
+                        data.attributes.pp.initial = Math.max(0, data.attributes.pp.initial + templateData.ppInitialMod);
+                        data.attributes.pp.tooltip = data.attributes.pp.tooltip || [];
+                        data.attributes.pp.tooltip.push(`${templateLabel} (Initial): ${templateData.ppInitialMod > 0 ? "+" : ""}${templateData.ppInitialMod}`);
+                    }
+                    if (templateData.ppMaxMod) {
+                        data.attributes.pp.max = Math.max(0, data.attributes.pp.max + templateData.ppMaxMod);
+                        data.attributes.pp.tooltip = data.attributes.pp.tooltip || [];
+                        data.attributes.pp.tooltip.push(`${templateLabel} (Max): ${templateData.ppMaxMod > 0 ? "+" : ""}${templateData.ppMaxMod}`);
+                    }
+                    if (templateData.ppRateMod) {
+                        data.attributes.pp.regen = Math.max(0, data.attributes.pp.regen + templateData.ppRateMod);
+                        data.attributes.pp.tooltip = data.attributes.pp.tooltip || [];
+                        data.attributes.pp.tooltip.push(`${templateLabel} (Regen): ${templateData.ppRateMod > 0 ? "+" : ""}${templateData.ppRateMod}`);
+                    }
+
+                    if (templateData.mpCostMultiplier > 0) {
+                        data.attributes.pp.templateMpCost = Math.floor(templateData.mpCostMultiplier * tier);
+                    }
+                }
+            }
         }
 
         // ========================================

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -3342,11 +3342,63 @@
             },
             "PowerCore": {
                 "Title": "Power Core",
+                "CoreType": "Core Type",
+                "CoreTypes": {
+                    "Dynamo": "Dynamo",
+                    "Eternal": "Eternal"
+                },
                 "PPInitial": "Initial PP",
                 "PPMax": "Maximum PP",
                 "PPRegen": "PP Regen/Turn",
                 "MpCost": "MP Cost",
-                "OnlyOne": "A mech can only have one power core."
+                "OnlyOne": "A mech can only have one power core.",
+                "Template": "Template",
+                "TemplateNone": "None",
+                "TemplatePPModifiers": "PP Modifiers",
+                "TemplateMpCost": "Template MP Cost",
+                "TemplateTier": "Tier",
+                "TemplateRestriction": "Restriction",
+                "TemplateRestrictionError": "This template requires: {requirement}",
+                "RestrictionEternal": "Eternal core only",
+                "RestrictionRateAbove1": "PP Regen/Turn greater than 1",
+                "Templates": {
+                    "Aeon": {
+                        "Name": "Aeon",
+                        "Description": "Operators can expend unused spell slots to grant PP equal to half the slot level (rounded down), once per round."
+                    },
+                    "Battle": {
+                        "Name": "Battle",
+                        "Description": "Optimized for combat, this template sacrifices regeneration rate for increased maximum capacity."
+                    },
+                    "Corpsegnawer": {
+                        "Name": "Corpsegnawer",
+                        "Description": "The mech can draw life energy from nearby corpses to boost its power regeneration rate.",
+                        "ActionName": "Draw Life Energy",
+                        "ActionDescription": "As a standard action, draw life energy from corpses within reach (dead no more than 1 minute). Increases PP regen rate by 1 for 1 round per 4 levels/CR of the creature. Creature must be at least half the mech's tier."
+                    },
+                    "Scrapper": {
+                        "Name": "Scrapper",
+                        "Description": "The mech gains 1d4 PP whenever it receives a system failure condition. Excess PP beyond maximum are lost after the next turn."
+                    },
+                    "Archadrenal": {
+                        "Name": "Archadrenal",
+                        "Description": "The mech can convert its own structural integrity into power, taking damage to generate PP.",
+                        "ActionName": "Convert HP to PP",
+                        "ActionDescription": "As a free action, take 3 × tier HP damage (unmitigated, but heals normally) to gain 1 PP."
+                    },
+                    "ArtificialInfandibulum": {
+                        "Name": "Artificial Infandibulum",
+                        "Description": "All weapons count as magical. Ammunition can be reloaded via PP. Energy weapons can activate twice per round and can switch damage types (fire/electricity/sonic). Energy weapon hits create a gravitation effect (Reflex DC 10 + half tier + STR mod, 20-ft push on hit).",
+                        "ReloadActionName": "Reload Ammunition",
+                        "ReloadActionDescription": "Spend 2 or more PP to reload ammunition for a mech weapon.",
+                        "DoubleFireActionName": "Double Fire (Energy)",
+                        "DoubleFireActionDescription": "Energy weapons can activate a second time per round (second activation deals lower damage tier). Can switch energy damage type to fire, electricity, or sonic."
+                    },
+                    "Concerto": {
+                        "Name": "Concerto",
+                        "Description": "Profession (musician) replaces standard operation checks (except scanning and repair). The mech gains a roadie operator who provides one additional action per round."
+                    }
+                }
             },
             "LowerLimb": {
                 "Title": "Lower Limb",

--- a/static/templates/items/mechPowerCore.hbs
+++ b/static/templates/items/mechPowerCore.hbs
@@ -44,6 +44,14 @@
                 <h3 class="bubble-header">{{ localize "SFRPG.MechSheet.PowerCore.Title" }}</h3>
                 <div class="bubble-info">
                     <div class="form-group">
+                        <label>{{ localize "SFRPG.MechSheet.PowerCore.CoreType" }}</label>
+                        <div class="form-fields">
+                            <select name="system.coreType">
+                                {{selectOptions (sfrpg "mechCoreTypes") selected=itemData.coreType localize=true}}
+                            </select>
+                        </div>
+                    </div>
+                    <div class="form-group">
                         <label>{{ localize "SFRPG.MechSheet.PowerCore.PPInitial" }}</label>
                         <div class="form-fields">
                             <input type="text" name="system.ppInitial" value="{{itemData.ppInitial}}" data-dtype="Number" />
@@ -67,6 +75,47 @@
                             <input type="text" name="system.mpCost" value="{{itemData.mpCost}}" data-dtype="Number" />
                         </div>
                     </div>
+                </div>
+            </div>
+
+            <div class="bubble">
+                <h3 class="bubble-header">{{ localize "SFRPG.MechSheet.PowerCore.Template" }}</h3>
+                <div class="bubble-info">
+                    <div class="form-group">
+                        <label>{{ localize "SFRPG.MechSheet.PowerCore.Template" }}</label>
+                        <div class="form-fields">
+                            <select name="system.template" class="power-core-template-select">
+                                <option value="">{{ localize "SFRPG.MechSheet.PowerCore.TemplateNone" }}</option>
+                                {{selectOptions (sfrpg "mechPowerCoreTemplateChoices") selected=itemData.template localize=true}}
+                            </select>
+                        </div>
+                    </div>
+
+                    {{#if templateInfo}}
+                    <div class="template-info">
+                        <p class="template-description">{{templateInfo.description}}</p>
+                        <div class="template-modifiers">
+                            {{#if templateInfo.hasModifiers}}
+                            <div class="form-group">
+                                <label>{{ localize "SFRPG.MechSheet.PowerCore.TemplatePPModifiers" }}</label>
+                                <span class="template-mod-values">{{templateInfo.modifierSummary}}</span>
+                            </div>
+                            {{/if}}
+                            {{#if templateInfo.mpCostDisplay}}
+                            <div class="form-group">
+                                <label>{{ localize "SFRPG.MechSheet.PowerCore.TemplateMpCost" }}</label>
+                                <span>{{templateInfo.mpCostDisplay}}</span>
+                            </div>
+                            {{/if}}
+                            {{#if templateInfo.restrictionDisplay}}
+                            <div class="form-group">
+                                <label>{{ localize "SFRPG.MechSheet.PowerCore.TemplateRestriction" }}</label>
+                                <span>{{templateInfo.restrictionDisplay}}</span>
+                            </div>
+                            {{/if}}
+                        </div>
+                    </div>
+                    {{/if}}
                 </div>
             </div>
 


### PR DESCRIPTION
## Summary
- Adds 7 power core templates (Aeon, Battle, Corpsegnawer, Scrapper, Archadrenal, Artificial Infandibulum, Concerto) from Tech Revolution and Mechageddon!
- Templates are selectable via dropdown on the power core item sheet's Details tab, with a Core Type field (Dynamo/Eternal) for restriction validation
- Selected templates auto-apply PP modifiers (rate/initial/max) in the rules engine with tooltips, and template actions appear in the mech Actions tab under Gear Actions
- Includes restriction validation (eternal-only, rate>1 checks) with error notifications

## Test plan
- [ ] Open a power core item from the Mech Components compendium
- [ ] Verify Core Type and Template dropdowns appear on the Details tab
- [ ] Select a template and confirm the info display shows description, PP modifiers, MP cost, and restriction
- [ ] Try selecting an invalid template (e.g., Aeon on a Dynamo core) and verify the error notification
- [ ] Add a power core with a template to a mech and verify PP stats reflect the template modifiers
- [ ] Verify template actions (Corpsegnawer, Archadrenal, Artificial Infandibulum) appear in the Actions tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)