### PR TITLE
Fix mech item sheets failing to render

### DIFF
--- a/src/module/handlebars.js
+++ b/src/module/handlebars.js
@@ -37,7 +37,8 @@ export const preloadHandlebarsTemplates = async function() {
         "systems/sfrpg/templates/items/parts/weapon-properties.hbs",
         "systems/sfrpg/templates/items/parts/damage-sections.hbs",
         "systems/sfrpg/templates/items/parts/item-duration.hbs",
-        "systems/sfrpg/templates/items/parts/effect-turn-events.hbs"
+        "systems/sfrpg/templates/items/parts/effect-turn-events.hbs",
+        "systems/sfrpg/templates/items/parts/mech-actions.hbs"
     ];
 
     return foundry.applications.handlebars.loadTemplates(templatePaths);


### PR DESCRIPTION
## Summary
- Added `mech-actions.hbs` to the Handlebars template preload list in `src/module/handlebars.js`
- The partial is referenced by `mechAuxiliary`, `mechWeapon`, `mechUpperLimb`, and `mechLowerLimb` templates but was never registered, causing an error when opening mech component item sheets

## Test plan
- [ ] Open a mech actor and click the edit icon on a mech component (weapon, upper limb, lower limb, or auxiliary)
- [ ] Verify the item sheet renders without errors