### PR TITLE
Fix Adamantine Claws damage type to slashing

### DIFF
--- a/src/items/mech-components/adamantine_claws.json
+++ b/src/items/mech-components/adamantine_claws.json
@@ -13,7 +13,7 @@
           "formula": "",
           "operator": "",
           "types": {
-            "bludgeoning": true
+            "slashing": true
           }
         }
       ]


### PR DESCRIPTION
## Summary
- Changed Adamantine Claws mech weapon damage type from bludgeoning to slashing

## Test plan
- [ ] Rebuild packs and verify Adamantine Claws shows slashing damage