### PR TITLE
Reset mech PP and remove conditions on combat start

### DIFF
--- a/changelist.md
+++ b/changelist.md
@@ -1,3 +1,22 @@
+# Version 0.32.0
+
+## New Features
+- Mech power points and conditions are automatically reset when combat starts
+- A GM-only whispered chat message summarizes which conditions were removed from each mech at combat start
+- Mech Actions tab with weapon attacks, PP actions, special actions, and gear actions
+- Mech initiative calculation and attribute tooltips
+- Mech upgrade bonus calculations and AC adjustments
+
+## Bugfixes
+- Fix mech item sheets failing to render due to missing mech-actions.hbs partial registration
+- Fix Adamantine Claws mech weapon damage type from bludgeoning to slashing
+- Fix mission pod item sheet statMods values and type label
+- Add ownership check before setting compendium flags
+
+## Core System Improvements
+- Manifest and download URLs updated to point to development branch
+- Power Points automatically regenerate each turn during mech combat
+
 # Version 0.31.0 - Mech Support
 This update adds mech support from the Starfinder Tech Revolution supplement.
 

--- a/src/items/mech-components/adamantine_claws.json
+++ b/src/items/mech-components/adamantine_claws.json
@@ -13,7 +13,7 @@
           "formula": "",
           "operator": "",
           "types": {
-            "bludgeoning": true
+            "slashing": true
           }
         }
       ]

--- a/src/sfrpg.js
+++ b/src/sfrpg.js
@@ -838,6 +838,69 @@ Hooks.on("renderAbstractSidebarTab", async (app) => {
     }
 });
 
+Hooks.on("combatStart", async (combat) => {
+    if (!game.users.activeGM?.isSelf) return;
+
+    const mechCombatants = combat.combatants.filter(c => c.actor?.type === "mech");
+    if (mechCombatants.length === 0) return;
+
+    const removedConditions = [];
+
+    for (const combatant of mechCombatants) {
+        const actor = combatant.actor;
+        const pp = actor.system.attributes.pp;
+
+        if (pp.value !== pp.initial) {
+            await actor.update({"system.attributes.pp.value": pp.initial});
+        }
+
+        const conditionNames = [];
+        for (const effect of CONFIG.SFRPG.statusEffects) {
+            if (actor.hasCondition(effect.id)) {
+                conditionNames.push(effect.id);
+            }
+        }
+
+        for (const conditionName of conditionNames) {
+            await actor.setCondition(conditionName, false);
+        }
+
+        if (conditionNames.length > 0) {
+            removedConditions.push({
+                name: actor.name,
+                conditions: conditionNames.map(c => game.i18n.localize(
+                    CONFIG.SFRPG.statusEffects.find(e => e.id === c).name
+                ))
+            });
+        }
+    }
+
+    const gmUsers = game.users.filter(u => u.isGM).map(u => u.id);
+    const lines = [game.i18n.localize("SFRPG.MechSheet.Actions.CombatResetTitle")];
+    for (const combatant of mechCombatants) {
+        const actor = combatant.actor;
+        const pp = actor.system.attributes.pp;
+        lines.push(game.i18n.format("SFRPG.MechSheet.Actions.CombatResetPP", {
+            name: actor.name,
+            value: pp.initial,
+            max: pp.max
+        }));
+    }
+    if (removedConditions.length > 0) {
+        for (const {name, conditions} of removedConditions) {
+            lines.push(game.i18n.format("SFRPG.MechSheet.Actions.CombatResetConditions", {
+                name,
+                conditions: conditions.join(", ")
+            }));
+        }
+    }
+
+    await ChatMessage.create({
+        content: lines.join("<br>"),
+        whisper: gmUsers
+    });
+});
+
 Hooks.on("onAfterUpdateCombat", async (eventData) => {
     if (!game.users.activeGM?.isSelf) return;
     if (!eventData.isNewTurn || !eventData.newCombatant) return;

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -2124,6 +2124,9 @@
                         "Name": "Resist"
                     }
                 },
+                "CombatResetConditions": "Removed conditions from {name}: {conditions}",
+                "CombatResetPP": "{name} PP reset to {value}/{max}",
+                "CombatResetTitle": "<strong>Mech Combat Start</strong>",
                 "PPActions": "PP Actions",
                 "PPRegenMessage": "{name} regenerates {amount} PP ({current}/{max})",
                 "PPSpent": "{amount} PP spent",


### PR DESCRIPTION
## Summary

- When combat starts, automatically resets all mech power points to their initial value and removes all active conditions
- Sends a GM-only whispered chat message summarizing what was reset (PP values and any removed conditions)
- Only affects actors of type `mech` in the combat; does nothing if no mechs are present

Closes #19