### PR TITLE
Fix mech item sheets failing to render by preloading mech-actions par…

### DIFF
--- a/src/module/handlebars.js
+++ b/src/module/handlebars.js
@@ -37,7 +37,8 @@ export const preloadHandlebarsTemplates = async function() {
         "systems/sfrpg/templates/items/parts/weapon-properties.hbs",
         "systems/sfrpg/templates/items/parts/damage-sections.hbs",
         "systems/sfrpg/templates/items/parts/item-duration.hbs",
-        "systems/sfrpg/templates/items/parts/effect-turn-events.hbs"
+        "systems/sfrpg/templates/items/parts/effect-turn-events.hbs",
+        "systems/sfrpg/templates/items/parts/mech-actions.hbs"
     ];
 
     return foundry.applications.handlebars.loadTemplates(templatePaths);


### PR DESCRIPTION
…tial

The mech-actions.hbs partial is referenced by mechAuxiliary, mechWeapon, mechUpperLimb, and mechLowerLimb templates but was never registered in preloadHandlebarsTemplates, causing a rendering error when editing mech components.