### PR TITLE
Skip mech PP/SP regen on backward combat navigation

### DIFF
--- a/src/sfrpg.js
+++ b/src/sfrpg.js
@@ -905,6 +905,7 @@ Hooks.on("combatStart", async (combat) => {
 Hooks.on("onAfterUpdateCombat", async (eventData) => {
     if (!game.users.activeGM?.isSelf) return;
     if (!eventData.isNewTurn || !eventData.newCombatant) return;
+    if (eventData.direction < 0) return;
 
     const actor = eventData.newCombatant.actor;
     if (!actor || actor.type !== "mech") return;


### PR DESCRIPTION
## Summary

- Checks `eventData.direction` in the `onAfterUpdateCombat` hook and skips PP/SP regeneration when direction is negative (backward navigation)
- Prevents mechs from gaining free resources when the GM clicks the back button in the combat tracker

Closes #26