### PR TITLE
Fix Scythe to use 2 upper limb slots

### DIFF
--- a/src/items/mech-components/acid_dart_rifle.json
+++ b/src/items/mech-components/acid_dart_rifle.json
@@ -36,6 +36,7 @@
       "descriptor": ""
     },
     "slot": "upperLimb",
+    "validSlots": ["frame", "upperLimb"],
     "source": "Tech Revolution pg. 108",
     "special": "automatic, corrode critical",
     "usage": 1,

--- a/src/items/mech-components/acid_dart_rifle.json
+++ b/src/items/mech-components/acid_dart_rifle.json
@@ -36,10 +36,13 @@
       "descriptor": ""
     },
     "slot": "upperLimb",
-    "validSlots": ["frame", "upperLimb"],
     "source": "Tech Revolution pg. 108",
     "special": "automatic, corrode critical",
     "usage": 1,
+    "validSlots": [
+      "frame",
+      "upperLimb"
+    ],
     "weaponType": "ranged"
   }
 }

--- a/src/items/mech-components/adamantine_claws.json
+++ b/src/items/mech-components/adamantine_claws.json
@@ -36,10 +36,13 @@
     },
     "slot": "lowerLimb",
     "slotsUsed": 2,
-    "validSlots": ["upperLimb", "lowerLimb"],
     "source": "Tech Revolution pg. 104",
     "special": "analog, penetrating",
     "usage": null,
+    "validSlots": [
+      "upperLimb",
+      "lowerLimb"
+    ],
     "weaponType": "melee"
   }
 }

--- a/src/items/mech-components/adamantine_claws.json
+++ b/src/items/mech-components/adamantine_claws.json
@@ -34,7 +34,9 @@
       "dc": null,
       "descriptor": ""
     },
-    "slot": "upperLimb",
+    "slot": "lowerLimb",
+    "slotsUsed": 2,
+    "validSlots": ["upperLimb", "lowerLimb"],
     "source": "Tech Revolution pg. 104",
     "special": "analog, penetrating",
     "usage": null,

--- a/src/items/mech-components/adamantine_claws.json
+++ b/src/items/mech-components/adamantine_claws.json
@@ -3,7 +3,7 @@
   "name": "Adamantine Claws",
   "type": "mechWeapon",
   "folder": "ufslMqZOMYF7vkkO",
-  "img": "systems/sfrpg/icons/equipment/weapons/plasma-claw-organic.webp",
+  "img": "systems/sfrpg/icons/classes/climbing_claws.webp",
   "system": {
     "area": "",
     "capacity": null,

--- a/src/items/mech-components/alloyed_sword.json
+++ b/src/items/mech-components/alloyed_sword.json
@@ -35,10 +35,12 @@
       "descriptor": ""
     },
     "slot": "upperLimb",
-    "validSlots": ["upperLimb"],
     "source": "Tech Revolution pg. 108",
     "special": "analog, penetrating, thrown (20 ft.)",
     "usage": null,
+    "validSlots": [
+      "upperLimb"
+    ],
     "weaponType": "melee"
   }
 }

--- a/src/items/mech-components/alloyed_sword.json
+++ b/src/items/mech-components/alloyed_sword.json
@@ -35,6 +35,7 @@
       "descriptor": ""
     },
     "slot": "upperLimb",
+    "validSlots": ["upperLimb"],
     "source": "Tech Revolution pg. 108",
     "special": "analog, penetrating, thrown (20 ft.)",
     "usage": null,

--- a/src/items/mech-components/anti-materiel_gun_pod.json
+++ b/src/items/mech-components/anti-materiel_gun_pod.json
@@ -36,10 +36,12 @@
       "descriptor": ""
     },
     "slot": "upperLimb",
-    "validSlots": ["upperLimb"],
     "source": "Mechageddon! pg. 153",
     "special": "blast, knockdown",
     "usage": 1,
+    "validSlots": [
+      "upperLimb"
+    ],
     "weaponType": "ranged"
   }
 }

--- a/src/items/mech-components/anti-materiel_gun_pod.json
+++ b/src/items/mech-components/anti-materiel_gun_pod.json
@@ -36,6 +36,7 @@
       "descriptor": ""
     },
     "slot": "upperLimb",
+    "validSlots": ["upperLimb"],
     "source": "Mechageddon! pg. 153",
     "special": "blast, knockdown",
     "usage": 1,

--- a/src/items/mech-components/arc_pulserifle.json
+++ b/src/items/mech-components/arc_pulserifle.json
@@ -35,10 +35,12 @@
       "descriptor": ""
     },
     "slot": "frame",
-    "validSlots": ["frame"],
     "source": "Mechageddon! pg. 153",
     "special": "arc",
     "usage": 1,
+    "validSlots": [
+      "frame"
+    ],
     "weaponType": "ranged"
   }
 }

--- a/src/items/mech-components/arc_pulserifle.json
+++ b/src/items/mech-components/arc_pulserifle.json
@@ -35,6 +35,7 @@
       "descriptor": ""
     },
     "slot": "frame",
+    "validSlots": ["frame"],
     "source": "Mechageddon! pg. 153",
     "special": "arc",
     "usage": 1,

--- a/src/items/mech-components/autospear.json
+++ b/src/items/mech-components/autospear.json
@@ -43,6 +43,8 @@
       "descriptor": ""
     },
     "slot": "upperLimb",
+    "slotsUsed": 2,
+    "validSlots": ["upperLimb"],
     "source": "Tech Revolution pg. 108",
     "special": "reach, thrown, projectile mode (1 PP)",
     "usage": 1,

--- a/src/items/mech-components/autospear.json
+++ b/src/items/mech-components/autospear.json
@@ -44,10 +44,12 @@
     },
     "slot": "upperLimb",
     "slotsUsed": 2,
-    "validSlots": ["upperLimb"],
     "source": "Tech Revolution pg. 108",
     "special": "reach, thrown, projectile mode (1 PP)",
     "usage": 1,
+    "validSlots": [
+      "upperLimb"
+    ],
     "weaponType": "ranged"
   }
 }

--- a/src/items/mech-components/battlestaff.json
+++ b/src/items/mech-components/battlestaff.json
@@ -36,10 +36,12 @@
     },
     "slot": "upperLimb",
     "slotsUsed": 2,
-    "validSlots": ["upperLimb"],
     "source": "Tech Revolution pg. 108",
     "special": "analog, blocking, reach, trip",
     "usage": null,
+    "validSlots": [
+      "upperLimb"
+    ],
     "weaponType": "melee"
   }
 }

--- a/src/items/mech-components/battlestaff.json
+++ b/src/items/mech-components/battlestaff.json
@@ -35,6 +35,8 @@
       "descriptor": ""
     },
     "slot": "upperLimb",
+    "slotsUsed": 2,
+    "validSlots": ["upperLimb"],
     "source": "Tech Revolution pg. 108",
     "special": "analog, blocking, reach, trip",
     "usage": null,

--- a/src/items/mech-components/buzzblade.json
+++ b/src/items/mech-components/buzzblade.json
@@ -35,10 +35,13 @@
       "descriptor": ""
     },
     "slot": "upperLimb",
-    "validSlots": ["upperLimb", "lowerLimb"],
     "source": "Tech Revolution pg. 108",
     "special": "bleed critical, cleave (2 PP)",
     "usage": null,
+    "validSlots": [
+      "upperLimb",
+      "lowerLimb"
+    ],
     "weaponType": "melee"
   }
 }

--- a/src/items/mech-components/buzzblade.json
+++ b/src/items/mech-components/buzzblade.json
@@ -35,6 +35,7 @@
       "descriptor": ""
     },
     "slot": "upperLimb",
+    "validSlots": ["upperLimb", "lowerLimb"],
     "source": "Tech Revolution pg. 108",
     "special": "bleed critical, cleave (2 PP)",
     "usage": null,

--- a/src/items/mech-components/chainwhip.json
+++ b/src/items/mech-components/chainwhip.json
@@ -43,6 +43,7 @@
       "descriptor": ""
     },
     "slot": "upperLimb",
+    "validSlots": ["upperLimb"],
     "source": "Tech Revolution pg. 108",
     "special": "analog, reach, trip, lash (2 PP)",
     "usage": null,

--- a/src/items/mech-components/chainwhip.json
+++ b/src/items/mech-components/chainwhip.json
@@ -43,10 +43,12 @@
       "descriptor": ""
     },
     "slot": "upperLimb",
-    "validSlots": ["upperLimb"],
     "source": "Tech Revolution pg. 108",
     "special": "analog, reach, trip, lash (2 PP)",
     "usage": null,
+    "validSlots": [
+      "upperLimb"
+    ],
     "weaponType": "melee"
   }
 }

--- a/src/items/mech-components/flame_doshko.json
+++ b/src/items/mech-components/flame_doshko.json
@@ -36,6 +36,8 @@
       "descriptor": ""
     },
     "slot": "upperLimb",
+    "slotsUsed": 2,
+    "validSlots": ["upperLimb"],
     "source": "Tech Revolution pg. 108",
     "special": "thrown (20 ft.), cleave (2 PP)",
     "usage": null,

--- a/src/items/mech-components/flame_doshko.json
+++ b/src/items/mech-components/flame_doshko.json
@@ -37,10 +37,12 @@
     },
     "slot": "upperLimb",
     "slotsUsed": 2,
-    "validSlots": ["upperLimb"],
     "source": "Tech Revolution pg. 108",
     "special": "thrown (20 ft.), cleave (2 PP)",
     "usage": null,
+    "validSlots": [
+      "upperLimb"
+    ],
     "weaponType": "melee"
   }
 }

--- a/src/items/mech-components/flamethrower.json
+++ b/src/items/mech-components/flamethrower.json
@@ -35,10 +35,12 @@
       "descriptor": ""
     },
     "slot": "upperLimb",
-    "validSlots": ["upperLimb"],
     "source": "Tech Revolution pg. 108",
     "special": "ignite, blast or line",
     "usage": 1,
+    "validSlots": [
+      "upperLimb"
+    ],
     "weaponType": "ranged"
   }
 }

--- a/src/items/mech-components/flamethrower.json
+++ b/src/items/mech-components/flamethrower.json
@@ -35,6 +35,7 @@
       "descriptor": ""
     },
     "slot": "upperLimb",
+    "validSlots": ["upperLimb"],
     "source": "Tech Revolution pg. 108",
     "special": "ignite, blast or line",
     "usage": 1,

--- a/src/items/mech-components/frost_rifle.json
+++ b/src/items/mech-components/frost_rifle.json
@@ -35,10 +35,13 @@
       "descriptor": ""
     },
     "slot": "upperLimb",
-    "validSlots": ["frame", "upperLimb"],
     "source": "Tech Revolution pg. 108",
     "special": "automatic, staggered critical",
     "usage": 1,
+    "validSlots": [
+      "frame",
+      "upperLimb"
+    ],
     "weaponType": "ranged"
   }
 }

--- a/src/items/mech-components/frost_rifle.json
+++ b/src/items/mech-components/frost_rifle.json
@@ -35,6 +35,7 @@
       "descriptor": ""
     },
     "slot": "upperLimb",
+    "validSlots": ["frame", "upperLimb"],
     "source": "Tech Revolution pg. 108",
     "special": "automatic, staggered critical",
     "usage": 1,

--- a/src/items/mech-components/frostspear.json
+++ b/src/items/mech-components/frostspear.json
@@ -44,6 +44,8 @@
       "descriptor": ""
     },
     "slot": "upperLimb",
+    "slotsUsed": 2,
+    "validSlots": ["upperLimb"],
     "source": "Tech Revolution pg. 108",
     "special": "reach, thrown (40 ft.), cold snap (2 PP)",
     "usage": null,

--- a/src/items/mech-components/frostspear.json
+++ b/src/items/mech-components/frostspear.json
@@ -45,10 +45,12 @@
     },
     "slot": "upperLimb",
     "slotsUsed": 2,
-    "validSlots": ["upperLimb"],
     "source": "Tech Revolution pg. 108",
     "special": "reach, thrown (40 ft.), cold snap (2 PP)",
     "usage": null,
+    "validSlots": [
+      "upperLimb"
+    ],
     "weaponType": "melee"
   }
 }

--- a/src/items/mech-components/grenade_launcher.json
+++ b/src/items/mech-components/grenade_launcher.json
@@ -33,10 +33,12 @@
       "descriptor": ""
     },
     "slot": "frame",
-    "validSlots": ["frame"],
     "source": "Tech Revolution pg. 108",
     "special": "fires grenades",
     "usage": 1,
+    "validSlots": [
+      "frame"
+    ],
     "weaponType": "ranged"
   }
 }

--- a/src/items/mech-components/grenade_launcher.json
+++ b/src/items/mech-components/grenade_launcher.json
@@ -32,7 +32,8 @@
       "dc": null,
       "descriptor": ""
     },
-    "slot": "upperLimb",
+    "slot": "frame",
+    "validSlots": ["frame"],
     "source": "Tech Revolution pg. 108",
     "special": "fires grenades",
     "usage": 1,

--- a/src/items/mech-components/gyroidal_drill_bit.json
+++ b/src/items/mech-components/gyroidal_drill_bit.json
@@ -1,0 +1,45 @@
+{
+  "_id": "6a7f4bf3338c2eb2",
+  "name": "Gyroidal Drill Bit",
+  "type": "mechWeapon",
+  "folder": "ufslMqZOMYF7vkkO",
+  "img": "systems/sfrpg/icons/equipment/weapons/grindblade.webp",
+  "system": {
+    "area": "",
+    "capacity": null,
+    "damage": {
+      "parts": [
+        {
+          "formula": "",
+          "operator": "",
+          "types": {
+            "piercing": true
+          }
+        }
+      ]
+    },
+    "damageLevel": "high",
+    "description": {
+      "chat": "",
+      "gmnotes": "",
+      "short": "",
+      "unidentified": "",
+      "value": "<p>A massive rotating drill designed to bore through heavy armor.</p>\n<p><strong>Critical:</strong> Bleed</p>\n<p><strong>Special:</strong> The first time a gyroidal drill bit deals damage to a target, the weapon gains the penetrating special property. If it damages the same target the next round, it loses this property and the amount of hardness the weapon ignores instead equals 3 × the mech's tier.</p>"
+    },
+    "mpCost": 3.5,
+    "ppCost": 0,
+    "range": "",
+    "save": {
+      "type": "",
+      "dc": null,
+      "descriptor": ""
+    },
+    "slot": "frame",
+    "slotsUsed": 2,
+    "validSlots": ["frame"],
+    "source": "Mechageddon! pg. 153",
+    "special": "shatter, bleed critical, penetrating (see description)",
+    "usage": null,
+    "weaponType": "melee"
+  }
+}

--- a/src/items/mech-components/gyroidal_drill_bit.json
+++ b/src/items/mech-components/gyroidal_drill_bit.json
@@ -36,10 +36,12 @@
     },
     "slot": "frame",
     "slotsUsed": 2,
-    "validSlots": ["frame"],
     "source": "Mechageddon! pg. 153",
     "special": "shatter, bleed critical, penetrating (see description)",
     "usage": null,
+    "validSlots": [
+      "frame"
+    ],
     "weaponType": "melee"
   }
 }

--- a/src/items/mech-components/hammerfist.json
+++ b/src/items/mech-components/hammerfist.json
@@ -35,10 +35,13 @@
       "descriptor": ""
     },
     "slot": "upperLimb",
-    "validSlots": ["upperLimb", "lowerLimb"],
     "source": "Tech Revolution pg. 108",
     "special": "analog, penetrating",
     "usage": null,
+    "validSlots": [
+      "upperLimb",
+      "lowerLimb"
+    ],
     "weaponType": "melee"
   }
 }

--- a/src/items/mech-components/hammerfist.json
+++ b/src/items/mech-components/hammerfist.json
@@ -35,6 +35,7 @@
       "descriptor": ""
     },
     "slot": "upperLimb",
+    "validSlots": ["upperLimb", "lowerLimb"],
     "source": "Tech Revolution pg. 108",
     "special": "analog, penetrating",
     "usage": null,

--- a/src/items/mech-components/laser_rifle.json
+++ b/src/items/mech-components/laser_rifle.json
@@ -34,7 +34,8 @@
       "dc": null,
       "descriptor": ""
     },
-    "slot": "upperLimb",
+    "slot": "frame",
+    "validSlots": ["frame"],
     "source": "Tech Revolution pg. 108",
     "special": "automatic, burn critical",
     "usage": 1,

--- a/src/items/mech-components/laser_rifle.json
+++ b/src/items/mech-components/laser_rifle.json
@@ -35,10 +35,12 @@
       "descriptor": ""
     },
     "slot": "frame",
-    "validSlots": ["frame"],
     "source": "Tech Revolution pg. 108",
     "special": "automatic, burn critical",
     "usage": 1,
+    "validSlots": [
+      "frame"
+    ],
     "weaponType": "ranged"
   }
 }

--- a/src/items/mech-components/massive_target_penetrating_weapon.json
+++ b/src/items/mech-components/massive_target_penetrating_weapon.json
@@ -36,6 +36,8 @@
       "descriptor": ""
     },
     "slot": "frame",
+    "slotsUsed": 2,
+    "validSlots": ["frame"],
     "source": "Mechageddon! pg. 153",
     "special": "penetrating",
     "usage": 1,

--- a/src/items/mech-components/massive_target_penetrating_weapon.json
+++ b/src/items/mech-components/massive_target_penetrating_weapon.json
@@ -37,10 +37,12 @@
     },
     "slot": "frame",
     "slotsUsed": 2,
-    "validSlots": ["frame"],
     "source": "Mechageddon! pg. 153",
     "special": "penetrating",
     "usage": 1,
+    "validSlots": [
+      "frame"
+    ],
     "weaponType": "ranged"
   }
 }

--- a/src/items/mech-components/mega_scattergun.json
+++ b/src/items/mech-components/mega_scattergun.json
@@ -36,10 +36,12 @@
     },
     "slot": "upperLimb",
     "slotsUsed": 2,
-    "validSlots": ["upperLimb"],
     "source": "Mechageddon! pg. 153",
     "special": "automatic, penetrating",
     "usage": 1,
+    "validSlots": [
+      "upperLimb"
+    ],
     "weaponType": "ranged"
   }
 }

--- a/src/items/mech-components/mega_scattergun.json
+++ b/src/items/mech-components/mega_scattergun.json
@@ -35,6 +35,8 @@
       "descriptor": ""
     },
     "slot": "upperLimb",
+    "slotsUsed": 2,
+    "validSlots": ["upperLimb"],
     "source": "Mechageddon! pg. 153",
     "special": "automatic, penetrating",
     "usage": 1,

--- a/src/items/mech-components/missile_battery.json
+++ b/src/items/mech-components/missile_battery.json
@@ -36,6 +36,7 @@
       "descriptor": ""
     },
     "slot": "frame",
+    "validSlots": ["frame"],
     "source": "Tech Revolution pg. 108",
     "special": "volley",
     "usage": 1,

--- a/src/items/mech-components/missile_battery.json
+++ b/src/items/mech-components/missile_battery.json
@@ -36,10 +36,12 @@
       "descriptor": ""
     },
     "slot": "frame",
-    "validSlots": ["frame"],
     "source": "Tech Revolution pg. 108",
     "special": "volley",
     "usage": 1,
+    "validSlots": [
+      "frame"
+    ],
     "weaponType": "ranged"
   }
 }

--- a/src/items/mech-components/plasma_rifle.json
+++ b/src/items/mech-components/plasma_rifle.json
@@ -36,10 +36,13 @@
       "descriptor": ""
     },
     "slot": "upperLimb",
-    "validSlots": ["frame", "upperLimb"],
     "source": "Tech Revolution pg. 108",
     "special": "line, wound critical",
     "usage": 1,
+    "validSlots": [
+      "frame",
+      "upperLimb"
+    ],
     "weaponType": "ranged"
   }
 }

--- a/src/items/mech-components/plasma_rifle.json
+++ b/src/items/mech-components/plasma_rifle.json
@@ -36,6 +36,7 @@
       "descriptor": ""
     },
     "slot": "upperLimb",
+    "validSlots": ["frame", "upperLimb"],
     "source": "Tech Revolution pg. 108",
     "special": "line, wound critical",
     "usage": 1,

--- a/src/items/mech-components/plasma_sword.json
+++ b/src/items/mech-components/plasma_sword.json
@@ -36,6 +36,7 @@
       "descriptor": ""
     },
     "slot": "upperLimb",
+    "validSlots": ["upperLimb"],
     "source": "Tech Revolution pg. 108",
     "special": "thrown (20 ft.)",
     "usage": null,

--- a/src/items/mech-components/plasma_sword.json
+++ b/src/items/mech-components/plasma_sword.json
@@ -36,10 +36,12 @@
       "descriptor": ""
     },
     "slot": "upperLimb",
-    "validSlots": ["upperLimb"],
     "source": "Tech Revolution pg. 108",
     "special": "thrown (20 ft.)",
     "usage": null,
+    "validSlots": [
+      "upperLimb"
+    ],
     "weaponType": "melee"
   }
 }

--- a/src/items/mech-components/rocket_launcher.json
+++ b/src/items/mech-components/rocket_launcher.json
@@ -44,6 +44,7 @@
       "descriptor": ""
     },
     "slot": "frame",
+    "validSlots": ["frame", "upperLimb"],
     "source": "Tech Revolution pg. 108",
     "special": "explode (10 ft.), unwieldy, siege mode (3 PP)",
     "usage": 1,

--- a/src/items/mech-components/rocket_launcher.json
+++ b/src/items/mech-components/rocket_launcher.json
@@ -44,10 +44,13 @@
       "descriptor": ""
     },
     "slot": "frame",
-    "validSlots": ["frame", "upperLimb"],
     "source": "Tech Revolution pg. 108",
     "special": "explode (10 ft.), unwieldy, siege mode (3 PP)",
     "usage": 1,
+    "validSlots": [
+      "frame",
+      "upperLimb"
+    ],
     "weaponType": "ranged"
   }
 }

--- a/src/items/mech-components/rotary_cannon.json
+++ b/src/items/mech-components/rotary_cannon.json
@@ -35,10 +35,13 @@
       "descriptor": ""
     },
     "slot": "upperLimb",
-    "validSlots": ["frame", "upperLimb"],
     "source": "Tech Revolution pg. 108",
     "special": "automatic",
     "usage": 1,
+    "validSlots": [
+      "frame",
+      "upperLimb"
+    ],
     "weaponType": "ranged"
   }
 }

--- a/src/items/mech-components/rotary_cannon.json
+++ b/src/items/mech-components/rotary_cannon.json
@@ -35,6 +35,7 @@
       "descriptor": ""
     },
     "slot": "upperLimb",
+    "validSlots": ["frame", "upperLimb"],
     "source": "Tech Revolution pg. 108",
     "special": "automatic",
     "usage": 1,

--- a/src/items/mech-components/scythe.json
+++ b/src/items/mech-components/scythe.json
@@ -44,6 +44,7 @@
     },
     "slot": "upperLimb",
     "slotsUsed": 2,
+    "validSlots": ["upperLimb"],
     "source": "Tech Revolution pg. 108",
     "special": "analog, reach, thrown (20 ft.), trip",
     "usage": null,

--- a/src/items/mech-components/scythe.json
+++ b/src/items/mech-components/scythe.json
@@ -43,6 +43,7 @@
       "descriptor": ""
     },
     "slot": "upperLimb",
+    "slotsUsed": 2,
     "source": "Tech Revolution pg. 108",
     "special": "analog, reach, thrown (20 ft.), trip",
     "usage": null,

--- a/src/items/mech-components/scythe.json
+++ b/src/items/mech-components/scythe.json
@@ -44,10 +44,12 @@
     },
     "slot": "upperLimb",
     "slotsUsed": 2,
-    "validSlots": ["upperLimb"],
     "source": "Tech Revolution pg. 108",
     "special": "analog, reach, thrown (20 ft.), trip",
     "usage": null,
+    "validSlots": [
+      "upperLimb"
+    ],
     "weaponType": "melee"
   }
 }

--- a/src/items/mech-components/shears.json
+++ b/src/items/mech-components/shears.json
@@ -35,6 +35,7 @@
       "descriptor": ""
     },
     "slot": "upperLimb",
+    "validSlots": ["upperLimb", "lowerLimb"],
     "source": "Tech Revolution pg. 108",
     "special": "wound critical",
     "usage": null,

--- a/src/items/mech-components/shears.json
+++ b/src/items/mech-components/shears.json
@@ -35,10 +35,13 @@
       "descriptor": ""
     },
     "slot": "upperLimb",
-    "validSlots": ["upperLimb", "lowerLimb"],
     "source": "Tech Revolution pg. 108",
     "special": "wound critical",
     "usage": null,
+    "validSlots": [
+      "upperLimb",
+      "lowerLimb"
+    ],
     "weaponType": "melee"
   }
 }

--- a/src/items/mech-components/sonic_shotgun.json
+++ b/src/items/mech-components/sonic_shotgun.json
@@ -35,6 +35,7 @@
       "descriptor": ""
     },
     "slot": "upperLimb",
+    "validSlots": ["frame", "upperLimb"],
     "source": "Tech Revolution pg. 108",
     "special": "blast, penetrating, knockdown critical",
     "usage": 1,

--- a/src/items/mech-components/sonic_shotgun.json
+++ b/src/items/mech-components/sonic_shotgun.json
@@ -35,10 +35,13 @@
       "descriptor": ""
     },
     "slot": "upperLimb",
-    "validSlots": ["frame", "upperLimb"],
     "source": "Tech Revolution pg. 108",
     "special": "blast, penetrating, knockdown critical",
     "usage": 1,
+    "validSlots": [
+      "frame",
+      "upperLimb"
+    ],
     "weaponType": "ranged"
   }
 }

--- a/src/items/mech-components/spear.json
+++ b/src/items/mech-components/spear.json
@@ -44,10 +44,12 @@
     },
     "slot": "upperLimb",
     "slotsUsed": 2,
-    "validSlots": ["upperLimb"],
     "source": "Tech Revolution pg. 108",
     "special": "analog, penetrating, reach, thrown (40 ft.)",
     "usage": null,
+    "validSlots": [
+      "upperLimb"
+    ],
     "weaponType": "melee"
   }
 }

--- a/src/items/mech-components/spear.json
+++ b/src/items/mech-components/spear.json
@@ -43,6 +43,8 @@
       "descriptor": ""
     },
     "slot": "upperLimb",
+    "slotsUsed": 2,
+    "validSlots": ["upperLimb"],
     "source": "Tech Revolution pg. 108",
     "special": "analog, penetrating, reach, thrown (40 ft.)",
     "usage": null,

--- a/src/items/mech-components/spiked_shield.json
+++ b/src/items/mech-components/spiked_shield.json
@@ -43,6 +43,8 @@
       "descriptor": ""
     },
     "slot": "upperLimb",
+    "slotsUsed": 2,
+    "validSlots": ["upperLimb"],
     "source": "Tech Revolution pg. 108",
     "special": "analog, block, deflect",
     "usage": null,

--- a/src/items/mech-components/spiked_shield.json
+++ b/src/items/mech-components/spiked_shield.json
@@ -44,10 +44,12 @@
     },
     "slot": "upperLimb",
     "slotsUsed": 2,
-    "validSlots": ["upperLimb"],
     "source": "Tech Revolution pg. 108",
     "special": "analog, block, deflect",
     "usage": null,
+    "validSlots": [
+      "upperLimb"
+    ],
     "weaponType": "melee"
   }
 }

--- a/src/items/mech-components/stinger_tail.json
+++ b/src/items/mech-components/stinger_tail.json
@@ -35,10 +35,13 @@
       "descriptor": ""
     },
     "slot": "frame",
-    "validSlots": ["frame", "lowerLimb"],
     "source": "Mechageddon! pg. 153",
     "special": "analog, corrode",
     "usage": null,
+    "validSlots": [
+      "frame",
+      "lowerLimb"
+    ],
     "weaponType": "melee"
   }
 }

--- a/src/items/mech-components/stinger_tail.json
+++ b/src/items/mech-components/stinger_tail.json
@@ -35,6 +35,7 @@
       "descriptor": ""
     },
     "slot": "frame",
+    "validSlots": ["frame", "lowerLimb"],
     "source": "Mechageddon! pg. 153",
     "special": "analog, corrode",
     "usage": null,

--- a/src/items/mech-components/swordwhip.json
+++ b/src/items/mech-components/swordwhip.json
@@ -43,10 +43,12 @@
       "descriptor": ""
     },
     "slot": "upperLimb",
-    "validSlots": ["upperLimb"],
     "source": "Tech Revolution pg. 108",
     "special": "whip mode (1 PP)",
     "usage": null,
+    "validSlots": [
+      "upperLimb"
+    ],
     "weaponType": "melee"
   }
 }

--- a/src/items/mech-components/swordwhip.json
+++ b/src/items/mech-components/swordwhip.json
@@ -43,6 +43,7 @@
       "descriptor": ""
     },
     "slot": "upperLimb",
+    "validSlots": ["upperLimb"],
     "source": "Tech Revolution pg. 108",
     "special": "whip mode (1 PP)",
     "usage": null,

--- a/src/items/mech-components/technosling.json
+++ b/src/items/mech-components/technosling.json
@@ -35,6 +35,7 @@
       "descriptor": ""
     },
     "slot": "upperLimb",
+    "validSlots": ["upperLimb"],
     "source": "Tech Revolution pg. 108",
     "special": "knockdown critical",
     "usage": 1,

--- a/src/items/mech-components/technosling.json
+++ b/src/items/mech-components/technosling.json
@@ -35,10 +35,12 @@
       "descriptor": ""
     },
     "slot": "upperLimb",
-    "validSlots": ["upperLimb"],
     "source": "Tech Revolution pg. 108",
     "special": "knockdown critical",
     "usage": 1,
+    "validSlots": [
+      "upperLimb"
+    ],
     "weaponType": "ranged"
   }
 }

--- a/src/items/mech-components/thundergauntlet.json
+++ b/src/items/mech-components/thundergauntlet.json
@@ -45,10 +45,12 @@
     },
     "slot": "upperLimb",
     "slotsUsed": 2,
-    "validSlots": ["upperLimb"],
     "source": "Tech Revolution pg. 108",
     "special": "thunderclap (1 PP)",
     "usage": null,
+    "validSlots": [
+      "upperLimb"
+    ],
     "weaponType": "melee"
   }
 }

--- a/src/items/mech-components/thundergauntlet.json
+++ b/src/items/mech-components/thundergauntlet.json
@@ -44,6 +44,8 @@
       "descriptor": ""
     },
     "slot": "upperLimb",
+    "slotsUsed": 2,
+    "validSlots": ["upperLimb"],
     "source": "Tech Revolution pg. 108",
     "special": "thunderclap (1 PP)",
     "usage": null,

--- a/src/items/mech-components/thundergauntlet.json
+++ b/src/items/mech-components/thundergauntlet.json
@@ -3,7 +3,7 @@
   "name": "Thundergauntlet",
   "type": "mechWeapon",
   "folder": "ufslMqZOMYF7vkkO",
-  "img": "systems/sfrpg/icons/equipment/weapons/plasma-claw-organic.webp",
+  "img": "systems/sfrpg/icons/classes/hammer_fist.webp",
   "system": {
     "actions": [
       {

--- a/src/module/actor/sheet/mech.js
+++ b/src/module/actor/sheet/mech.js
@@ -164,6 +164,8 @@ export class ActorSheetSFRPGMech extends ActorSheetSFRPG {
         const lowerLimbWeapons = weapons.filter(w => w.system.slot === "lowerLimb");
         const lockerWeapons = weapons.filter(w => w.system.slot === "locker");
 
+        const sumSlots = (wpns) => wpns.reduce((sum, w) => sum + (w.system.slotsUsed || 1), 0);
+
         // Sort auxiliary systems alphabetically by name
         auxiliarySystems.sort((a, b) => a.name.localeCompare(b.name));
 
@@ -171,6 +173,10 @@ export class ActorSheetSFRPGMech extends ActorSheetSFRPG {
         const frameSlots = actorData.attributes?.slots?.frame || 0;
         const upperLimbSlots = actorData.attributes?.slots?.upperLimb || 0;
         const lowerLimbSlots = actorData.attributes?.slots?.lowerLimb || 0;
+
+        const frameSlotsUsed = sumSlots(frameWeapons);
+        const upperLimbSlotsUsed = sumSlots(upperLimbWeapons);
+        const lowerLimbSlotsUsed = sumSlots(lowerLimbWeapons);
 
         // Check if components exist
         const hasFrame = frames.length > 0;
@@ -185,10 +191,10 @@ export class ActorSheetSFRPGMech extends ActorSheetSFRPG {
                 dataset: { type: "mechFrame" },
                 allowAdd: frames.length < 1,
                 weapons: frameWeapons,
-                weaponSlots: { used: frameWeapons.length, max: frameSlots },
+                weaponSlots: { used: frameSlotsUsed, max: frameSlots },
                 slotType: "frame",
                 hasComponent: hasFrame,
-                allowAddWeapon: hasFrame && frameWeapons.length < frameSlots
+                allowAddWeapon: hasFrame && frameSlotsUsed < frameSlots
             },
             powerCores: {
                 category: game.i18n.format("SFRPG.MechSheet.Features.PowerCores", { current: powerCores.length }),
@@ -204,10 +210,10 @@ export class ActorSheetSFRPGMech extends ActorSheetSFRPG {
                 dataset: { type: "mechLowerLimb" },
                 allowAdd: lowerLimbs.length < 1,
                 weapons: lowerLimbWeapons,
-                weaponSlots: { used: lowerLimbWeapons.length, max: lowerLimbSlots },
+                weaponSlots: { used: lowerLimbSlotsUsed, max: lowerLimbSlots },
                 slotType: "lowerLimb",
                 hasComponent: hasLowerLimb,
-                allowAddWeapon: hasLowerLimb && lowerLimbWeapons.length < lowerLimbSlots
+                allowAddWeapon: hasLowerLimb && lowerLimbSlotsUsed < lowerLimbSlots
             },
             upperLimbs: {
                 category: game.i18n.format("SFRPG.MechSheet.Features.UpperLimbs", { current: upperLimbs.length }),
@@ -216,10 +222,10 @@ export class ActorSheetSFRPGMech extends ActorSheetSFRPG {
                 dataset: { type: "mechUpperLimb" },
                 allowAdd: upperLimbs.length < 1,
                 weapons: upperLimbWeapons,
-                weaponSlots: { used: upperLimbWeapons.length, max: upperLimbSlots },
+                weaponSlots: { used: upperLimbSlotsUsed, max: upperLimbSlots },
                 slotType: "upperLimb",
                 hasComponent: hasUpperLimb,
-                allowAddWeapon: hasUpperLimb && upperLimbWeapons.length < upperLimbSlots
+                allowAddWeapon: hasUpperLimb && upperLimbSlotsUsed < upperLimbSlots
             },
             auxiliarySystems: {
                 category: game.i18n.format("SFRPG.MechSheet.Features.AuxiliarySystems"),
@@ -727,13 +733,14 @@ export class ActorSheetSFRPGMech extends ActorSheetSFRPG {
         const actorData = this.actor.system;
 
         // Check which slots have components and available capacity
+        const weaponSlotsNeeded = itemData.system.slotsUsed || 1;
         const availableSlots = [];
         for (const slot of validSlots) {
             const hasComponent = this._hasComponentForSlot(slot);
-            const slotsUsed = this._getWeaponsInSlot(slot).length;
+            const slotsUsed = this._getWeaponsInSlot(slot).reduce((sum, w) => sum + (w.system.slotsUsed || 1), 0);
             const maxSlots = actorData.attributes?.slots?.[slot] || 0;
 
-            if (hasComponent && slotsUsed < maxSlots) {
+            if (hasComponent && slotsUsed + weaponSlotsNeeded <= maxSlots) {
                 availableSlots.push({
                     slot,
                     label: game.i18n.localize(CONFIG.SFRPG.mechWeaponMountableSlots[slot]),

--- a/src/module/data/item/mechWeapon.mjs
+++ b/src/module/data/item/mechWeapon.mjs
@@ -46,6 +46,14 @@ export default class SFRPGItemMechWeapon extends SFRPGItemBase {
                 required: true,
                 label: "SFRPG.MechSheet.Weapon.Slot"
             }),
+            slotsUsed: new fields.NumberField({
+                initial: 1,
+                min: 1,
+                integer: true,
+                nullable: false,
+                required: true,
+                label: "SFRPG.MechSheet.Weapon.SlotsUsed"
+            }),
             validSlots: new fields.ArrayField(
                 new fields.StringField({
                     choices: Object.keys(CONFIG.SFRPG?.mechWeaponMountableSlots || {

--- a/src/module/item/sheet.js
+++ b/src/module/item/sheet.js
@@ -654,6 +654,17 @@ export class ItemSheetSFRPG extends foundry.appv1.sheets.ItemSheet {
             formData["system.quantity"] = newValue;
         }
 
+        // Handle validSlots checkboxes -> array conversion for mechWeapon
+        if (this.object.type === "mechWeapon") {
+            const validSlots = [];
+            for (const slot of ["frame", "upperLimb", "lowerLimb"]) {
+                const key = `system.validSlots.${slot}`;
+                if (formData[key]) validSlots.push(slot);
+                delete formData[key];
+            }
+            formData["system.validSlots"] = validSlots;
+        }
+
         // Update the Item
         return super._updateObject(event, formData);
     }

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -2371,6 +2371,7 @@
                 "PpCost": "PP Cost",
                 "Range": "Range",
                 "Slot": "Weapon Slot",
+                "SlotsUsed": "Slots Used",
                 "SlotFrame": "Frame",
                 "SlotLocker": "Weapons Locker",
                 "SlotLowerLimb": "Lower Limb",

--- a/static/templates/items/mechWeapon.hbs
+++ b/static/templates/items/mechWeapon.hbs
@@ -84,6 +84,23 @@
                         </div>
                     </div>
                     <div class="form-group">
+                        <label>{{ localize "SFRPG.MechSheet.Weapon.ValidSlots" }}</label>
+                        <div class="form-fields">
+                            <label class="checkbox">
+                                <input type="checkbox" name="system.validSlots.frame" {{checked (contains itemData.validSlots "frame")}} />
+                                {{ localize "SFRPG.MechSheet.Weapon.SlotFrame" }}
+                            </label>
+                            <label class="checkbox">
+                                <input type="checkbox" name="system.validSlots.upperLimb" {{checked (contains itemData.validSlots "upperLimb")}} />
+                                {{ localize "SFRPG.MechSheet.Weapon.SlotUpperLimb" }}
+                            </label>
+                            <label class="checkbox">
+                                <input type="checkbox" name="system.validSlots.lowerLimb" {{checked (contains itemData.validSlots "lowerLimb")}} />
+                                {{ localize "SFRPG.MechSheet.Weapon.SlotLowerLimb" }}
+                            </label>
+                        </div>
+                    </div>
+                    <div class="form-group">
                         <label>{{ localize "SFRPG.MechSheet.Weapon.Range" }}</label>
                         <div class="form-fields">
                             <input type="text" name="system.range" value="{{itemData.range}}" />

--- a/static/templates/items/mechWeapon.hbs
+++ b/static/templates/items/mechWeapon.hbs
@@ -78,6 +78,12 @@
                         </div>
                     </div>
                     <div class="form-group">
+                        <label>{{ localize "SFRPG.MechSheet.Weapon.SlotsUsed" }}</label>
+                        <div class="form-fields">
+                            <input type="text" name="system.slotsUsed" value="{{itemData.slotsUsed}}" data-dtype="Number" />
+                        </div>
+                    </div>
+                    <div class="form-group">
                         <label>{{ localize "SFRPG.MechSheet.Weapon.Range" }}</label>
                         <div class="form-fields">
                             <input type="text" name="system.range" value="{{itemData.range}}" />


### PR DESCRIPTION
## Summary

- Adds `slotsUsed` field to the mechWeapon data model (default 1) to support weapons that occupy multiple slots
- Updates slot capacity checks in the mech sheet to sum `slotsUsed` instead of counting weapons by array length
- Updates the weapon drop handler to check available capacity against the weapon's `slotsUsed` value
- Sets Scythe to `slotsUsed: 2` per Tech Revolution pg. 108
- Adds "Slots Used" field to the mech weapon item sheet for GM editing
- Adds localization string for the new field

Closes #16